### PR TITLE
CORE-7254: Incorrectly rewriting queries without a GROUP BY to use a grouped rollup.

### DIFF
--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
@@ -270,4 +270,20 @@ class TestQueryRewriter extends TestQueryRewriterBase {
 
     rewrites should have size 1
   }
+
+  test("don't map query 'select ward' to grouped rollups") {
+    val q = "SELECT ward"
+    val queryAnalysis = analyzeQuery(q)
+
+    val rewrittenQuery = "SELECT c1 AS ward"
+
+    val rewrittenQueryAnalysis = analyzeRewrittenQuery("r6", rewrittenQuery)
+
+    val rewrites = rewriter.possibleRewrites(queryAnalysis, rollupAnalysis)
+
+    rewrites should contain key "r6"
+    rewrites.get("r6").get should equal(rewrittenQueryAnalysis)
+
+    rewrites should have size 1
+  }
 }


### PR DESCRIPTION
In the case where the query didn't have a GROUP BY on it, but the
rollup did, we could incorrectly rewrite the query to use the rollup
resulting in incorrect results if all the columns in the query are
in a rollup.

We now will only do the rewrite if all the columns are aggregates.
The Selection rewrite will ensure the aggregates can be mapped
appropriately to the rollup's Selection by either being self
aggregatable or falling into some other specific special aggregation
case.