### PR TITLE
Add basic support for selecting the best rollup when doing query rewrite.

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/RollupScorer.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/RollupScorer.scala
@@ -1,0 +1,83 @@
+package com.socrata.querycoordinator
+
+import com.socrata.soql.functions.SoQLFunctions
+import com.typesafe.scalalogging.slf4j.Logging
+
+/**
+ * A very trivial rule based optimizer that assigns scores to rollups to try to determine which is the best one to
+ * query given multiple options.  In a world of great complexity this approach is more or less doomed to failure
+ * due to not having enough information, however it is simple to implement the simple cases and can go a long way and
+ * we don't need to be at the level of sophisitication of an advanced cost based optimizer.  If we ever do we are
+ * probably barking up the wrong tree.
+ *
+ * All decisions are made off the structure of the rollup with no insight into the actual size of the rollup
+ * or the actual query execution plan.
+ *
+ * A score is assigned by adding up the following laughingly simplistic rules:
+ *
+ * - Number of GROUP BY clauses
+ *  - 0
+ *   - If all functions are aggregates, 0 since this should be a one line rollup!
+ *   - Else 100000 * the number of columns in the selection to greatly penalize this non-rollup rollup
+ *  - >0 then 100 * the number of GROUP BYs, with the assumption each one increases the size of the rollup
+ * - For each "top level" AND clause in the WHERE clause, reduce the score by 10 points with the assumption each one
+ *   makes the rollup smaller.
+ * - For each value in the selection, give a minor penalty of 1
+ *
+ */
+import QueryRewriter._
+
+private object RollupScorer extends Logging {
+  private val SELECTION_SCORE_PENALTY = -10L
+
+  def scoreRollup(r: Anal): Long = {
+      val whereScore = r.where match {
+        case Some(w) => SELECTION_SCORE_PENALTY /* for a single filter */ +
+          scoreExpr(w) /* recursively look for ANDs */
+        case _ => 0
+    }
+    val score = scoreGroup(r) +
+      1 * r.selection.size /* slight penalty for more columns in the selection */ +
+      whereScore
+
+    logger.trace(s"Scored rollup $r as $score (whereScore=$whereScore)}")
+    score
+  }
+
+  def scoreGroup(r: Anal): Long = {
+    r.groupBy match {
+      case None =>
+        r.selection.forall {
+          case (_, fc: FunctionCall) if fc.function.isAggregate => true
+          case _ => false
+        } match {
+          // everything is an aggregate so this should be one row, nice!
+          case true => 0
+          // no aggregation, stiff penalty so we don't use this unless we have to
+          case false => 100000 * r.selection.size
+        }
+      // assume each group by increases the size.  This is assuming a linear increase even
+      // though it typically isn't that simple.
+      case Some(g) => 100 * g.length
+    }
+  }
+
+  def scoreExpr(e: Expr): Long = {
+    val score = e match {
+      case fc: FunctionCall if fc.function.function == SoQLFunctions.And =>
+        fc.parameters.foldLeft(SELECTION_SCORE_PENALTY)(_ + scoreExpr(_))
+      case _ => 0
+    }
+    logger.trace(s"Scored value of $score for expr $e")
+    score
+  }
+
+  /** Returns a sorted Seq of rollups, from best to worst. */
+  def sortByScore(rollups: Seq[(RollupName, Anal)]): Seq[(RollupName, Anal)] = {
+    rollups.sortBy(r => RollupScorer.scoreRollup(r._2))
+  }
+
+  def bestRollup(rollups: Seq[(RollupName, Anal)]): Option[(RollupName, Anal)] = {
+    sortByScore(rollups).headOption
+  }
+}

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -219,7 +219,8 @@ class QueryResource(secondary: Secondary,
         } else {
           rollupInfoFetcher(base.receiveTimeoutMS(schemaTimeout.toMillis.toInt), dataset, copy) match {
             case RollupInfoFetcher.Successful(rollups) =>
-              val rewritten = queryRewriter.bestRewrite(schema, analyzedQuery, rollups)
+              val rewritten = RollupScorer.bestRollup(
+                queryRewriter.possibleRewrites(schema, analyzedQuery, rollups).toSeq)
               val (rollupName, analysis) = rewritten map { x => (Some(x._1), x._2) } getOrElse ((None, analyzedQuery))
               log.info(s"Rewrote query on dataset $dataset to rollup $rollupName with analysis $analysis")
               (analysis, rollupName)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
@@ -1,5 +1,6 @@
 package com.socrata.querycoordinator
 
+import com.socrata.querycoordinator.QueryRewriter.{RollupName, Anal}
 import com.socrata.soql.SoQLAnalysis
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types.SoQLAnalysisType
@@ -15,14 +16,11 @@ class TestQueryRewriter extends TestQueryRewriterBase {
     ("r1", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) GROUP BY `_dxyz-num1`"),
     ("r2", "SELECT count(`:wido-ward`), `:wido_ward` GROUP BY `:wido-ward`"),
     ("r3", "SELECT `:wido-ward`, count(*) GROUP BY `:wido-ward`"),
-    ("r4", "SELECT `:wido-ward`, `_crim-typ3`, count(*), `_dxyz-num1`, " +
-      "`_crim-date` GROUP BY `:wido-ward`, `_crim-typ3`, `_dxyz-num1`, `_crim-date`"),
+    ("r4", "SELECT `:wido-ward`, `_crim-typ3`, count(*), `_dxyz-num1`, `_crim-date` GROUP BY `:wido-ward`, `_crim-typ3`, `_dxyz-num1`, `_crim-date`"),
     ("r5", "SELECT `_crim-typ3`, count(1) group by `_crim-typ3`"),
     ("r6", "SELECT `:wido-ward`, `_crim-typ3`"),
-    ("r7", "SELECT `:wido-ward`, min(`_dxyz-num1`), max(`_dxyz-num1`), " +
-      "sum(`_dxyz-num1`), count(*) GROUP BY `:wido-ward`"),
-    ("r8", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, " +
-      "count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`")
+    ("r7", "SELECT `:wido-ward`, min(`_dxyz-num1`), max(`_dxyz-num1`), sum(`_dxyz-num1`), count(*) GROUP BY `:wido-ward`"),
+    ("r8", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`")
   )
 
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
@@ -30,7 +28,7 @@ class TestQueryRewriter extends TestQueryRewriterBase {
   /** Pull in the rollupAnalysis for easier debugging */
   val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
 
-  val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: rewriter.Anal =>
+  val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>
       rewriter.rollupColumnId(idx) -> expr.typ.canonical
     }.toMap

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -1,5 +1,6 @@
 package com.socrata.querycoordinator
 
+import com.socrata.querycoordinator.QueryRewriter.ColumnId
 import com.socrata.soql.{SoQLAnalysis, SoQLAnalyzer}
 import com.socrata.soql.environment.{ColumnName, TypeName}
 import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
@@ -23,7 +24,7 @@ class TestQueryRewriterBase extends TestBase {
   val schema = Schema("NOHASH", rawSchema, "NOPK")
 
   /** Mapping from column name to column id, that we get from soda fountain with the query.  */
-  val columnIdMapping = Map[ColumnName, rewriter.ColumnId](
+  val columnIdMapping = Map[ColumnName, ColumnId](
     ColumnName("number1") -> "dxyz-num1",
     ColumnName("ward") -> ":wido-ward",
     ColumnName("crime_type") -> "crim-typ3",
@@ -36,7 +37,7 @@ class TestQueryRewriterBase extends TestBase {
   val dsContext = QueryParser.dsContext(columnIdMapping, rawSchema)
 
   /** Analyze the query and map to column ids, just like we have in real life. */
-  def analyzeQuery(q: String): SoQLAnalysis[rewriter.ColumnId, SoQLAnalysisType] =
+  def analyzeQuery(q: String): SoQLAnalysis[ColumnId, SoQLAnalysisType] =
     analyzer.analyzeFullQuery(q)(dsContext).mapColumnIds(columnIdMapping)
 
   /** Silly half-assed function for debugging when things don't match */

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -1,5 +1,6 @@
 package com.socrata.querycoordinator
 
+import com.socrata.querycoordinator.QueryRewriter.{RollupName, Anal}
 import com.socrata.soql.SoQLAnalysis
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types.SoQLAnalysisType
@@ -22,7 +23,7 @@ class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
   /** Pull in the rollupAnalysis for easier debugging */
   val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
 
-  val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: rewriter.Anal =>
+  val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>
       rewriter.rollupColumnId(idx) -> expr.typ.canonical
     }.toMap
@@ -42,6 +43,6 @@ class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
     rewrittenQueryAnalysis
   }
 
-  def rewritesFor(q: String): Map[rewriter.RollupName, rewriter.Anal] =
+  def rewritesFor(q: String): Map[RollupName, Anal] =
     rewriter.possibleRewrites(analyzeQuery(q), rollupAnalysis)
 }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
@@ -1,0 +1,42 @@
+package com.socrata.querycoordinator
+
+class TestRollupScorer extends TestQueryRewriterBase {
+
+  test("rollup scoring") {
+    /** Each rollup here is defined by:
+      * - a name
+      * - a soql statement.  Note this must be the mapped statement,
+      * i.e. non-system columns prefixed by an _, and backtick escaped
+      * - a Seq of the soql types for each column in the rollup selection
+      *
+      * They need to be ORDERED in "best" to worst order and all have distinct scores to ensure there are
+      * no ties.
+      */
+    val rollups = Seq(
+      ("r1", "SELECT sum(`_dxyz-num1`)"),
+      ("r2", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL AND `:wido-ward` = 8 GROUP BY `_dxyz-num1` "),
+      ("r3", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
+      ("r4", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
+      ("r5", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) GROUP BY `_dxyz-num1`"),
+      ("r6", "SELECT `:wido-ward`, min(`_dxyz-num1`), max(`_dxyz-num1`), sum(`_dxyz-num1`), count(*) GROUP BY `:wido-ward`"),
+      ("r7", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`"),
+      ("r8", "SELECT `:wido-ward`, `_crim-typ3`, count(*), `_dxyz-num1`, `_crim-date` GROUP BY `:wido-ward`, `_crim-typ3`, `_dxyz-num1`, `_crim-date`"),
+      ("r9", "SELECT `:wido-ward`"),
+      ("ra", "SELECT `:wido-ward`, `_crim-typ3`")
+    )
+
+    val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
+
+    /** Pull in the rollupAnalysis for easier debugging */
+    val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
+
+    // validate we don't have any ties, which could confuse things due to having no clear ordering.
+    rollupAnalysis.values.map(RollupScorer.scoreRollup(_)).toSet should have size rollups.size
+
+    val sorted = RollupScorer.sortByScore(rollupAnalysis.toSeq)
+
+    sorted.map(_._1) should equal (rollups.map(_._1))
+
+    RollupScorer.bestRollup(rollupAnalysis.toSeq).map(_._1) should equal (Some("r1"))
+  }
+}


### PR DESCRIPTION
This is essentially a simple "rule based" optimizer that looks at the structure of the
rollup to assign it a score based on how expensive we think it might be to query.
We do not consider the particulars of the query, just the rollup.

Please see the docs in com.socrata.querycoordinator.RollupScorer for an explaination
of how it functions.