### PR TITLE
EN-4339: Don't log strack traces for failures to parse rollups.

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -3,6 +3,7 @@ package com.socrata.querycoordinator
 import com.socrata.querycoordinator.QueryRewriter._
 import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.exceptions.SoQLException
 import com.socrata.soql.functions.SoQLFunctions._
 import com.socrata.soql.functions._
 import com.socrata.soql.types._
@@ -424,7 +425,8 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLType]) {
     }
 
     analysisMap.foreach {
-      case (k, Failure(e)) => log.warn(s"Couldn't parse rollup '${rollupMap.get(k).get}'", e)
+      case (rollupName, Failure(e: SoQLException)) => log.info(s"Couldn't parse rollup $rollupName, ignoring: ${e.toString}")
+      case (rollupName, Failure(e)) => log.warn(s"Couldn't parse rollup $rollupName due to unexpected failure, ignoring", e)
       case _ =>
     }
 


### PR DESCRIPTION
We have soql parse errors for various "valid"-ish reasons, such as
columns being removed without the rollup being updated, there isn't
any real value to logging a stack trace for a SoQLException.  Still
warn about other unexpected errors with stack trace.