### PR TITLE
Shouldn't touch columns that are not expanded.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val postgresql = "9.4.1207.jre7"
     val socrataHttpVersion = "3.3.1"
     val protobuf = "2.4.1"
-    val rojomaJson = "3.2.0"
+    val rojomaJson = "3.5.0"
     val socrataCuratorUtils = "1.0.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryExecutor.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryExecutor.scala
@@ -203,7 +203,8 @@ class QueryExecutor(httpClient: HttpClient,
               cache.start()
               ready.acquire()
 
-              val jvalues = JsonArrayIterator[JValue](new FusedBlockJsonEventIterator(new InputStreamReader(forForward, StandardCharsets.UTF_8)))
+              val jvalues = JsonArrayIterator.fromEvents[JValue](new FusedBlockJsonEventIterator(
+                new InputStreamReader(forForward, StandardCharsets.UTF_8)))
               val cjsonHeader = jvalues.next()
 
               val interestingSubset = takeBigInt(dropBigInt(jvalues, origOffset - newOffset), origLimit)
@@ -218,7 +219,7 @@ class QueryExecutor(httpClient: HttpClient,
 
   private def parseWindowInScope(window: ValueRef, rs: ResourceScope): Iterator[JValue] = new Iterator[JValue] {
     val stream = window.openText(rs)
-    val underlying = JsonArrayIterator[JValue](new FusedBlockJsonEventIterator(stream))
+    val underlying = JsonArrayIterator.fromEvents[JValue](new FusedBlockJsonEventIterator(stream))
     var seenEOF = false
     def hasNext = {
       if(!seenEOF && !underlying.hasNext) { seenEOF = true; rs.close(stream); rs.close(window) }
@@ -243,7 +244,8 @@ class QueryExecutor(httpClient: HttpClient,
                       startWindow: BigInt,
                       endWindow: BigInt): Unit = {
     val abort = { (why: String) => log.warn(why); return } // this "return" needs to return from doCache, not abort.  Thus val not def
-    val jvalues = JsonArrayIterator[JValue](new FusedBlockJsonEventIterator(new InputStreamReader(body, StandardCharsets.UTF_8)))
+    val jvalues = JsonArrayIterator.fromEvents[JValue](new FusedBlockJsonEventIterator(
+        new InputStreamReader(body, StandardCharsets.UTF_8)))
     val cjsonHeader = jvalues.next()
     // ok, we'll need to make a new cache key based on the headers
     val headers = Headers(httpHeaders, cjsonHeader)

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
@@ -72,7 +72,12 @@ class CompoundTypeFuser(fuseBase: Map[String, String]) extends SoQLRewrite with 
       case SelectedExpression(expr: Expression, namePos) =>
         rewrite(expr) match {
           case Some(rwExpr) =>
-            val alias = namePos.orElse(Some((ColumnName(ColumnPrefix + expr.toSyntheticIdentifierBase), NoPosition)))
+            val alias =
+              if (expr.eq(rwExpr)) { // Do not change the original name if the expression is not rewritten.
+                namePos
+              } else {
+                namePos.orElse(Some((ColumnName(ColumnPrefix + expr.toSyntheticIdentifierBase), NoPosition)))
+              }
             Seq(SelectedExpression(rwExpr, alias))
           case None =>
             Seq.empty


### PR DESCRIPTION
system columns lose their prefix ':'