### PR TITLE
EN-5910: Use Java8 base image for dockerizing query-coordinator

### DIFF
--- a/query-coordinator/docker/Dockerfile
+++ b/query-coordinator/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/java
+FROM socrata/java8
 
 EXPOSE 6030 6031
 ENV JMX_PORT 6039


### PR DESCRIPTION
Jenkins jobs are updated to build the code with Java 8. Build passed in Jenkins and container is running fine in staging under Java 8.