### PR TITLE
Fusing columns does not play nicely with chained soql even when fusin…

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
@@ -105,12 +105,13 @@ class CompoundTypeFuser(fuseBase: Map[String, String]) extends SoQLRewrite with 
    * Columns involved are prefixed during ast rewrite and removed after analysis to avoid column name conflicts.
    */
   def postAnalyze(analyses: Seq[SoQLAnalysis[ColumnName, SoQLType]]): Seq[SoQLAnalysis[ColumnName, SoQLType]] = {
-    analyses.map { a =>
-      val selection = a.selection map { case (cn, expr) =>
+    val last = analyses.last
+    val newSelect = last.selection map {
+      case (cn, expr) =>
         (ColumnName(cn.name.replaceFirst(ColumnPrefix, "")) -> expr)
-      }
-      a.copy(selection = selection)
     }
+
+    analyses.updated(analyses.size - 1, last.copy(selection = newSelect))
   }
 
   private def rewrite(expr: Expression): Option[Expression] = {

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/QueryParserFuseTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/QueryParserFuseTest.scala
@@ -15,33 +15,10 @@ class QueryParserFuseTest extends TestBase {
   import QueryParserFuseTest._ // scalastyle:ignore import.grouping
 
   test("SELECT * -- compound type fusing") {
-    val query = "select * where location.latitude = 1.1"
-    val starPos = query.indexOf("*") + 1
-
-    val locationFc = FunctionCall(SoQLFunctions.Location.monomorphic.get, Seq(
-      ColumnRef("location", SoQLPoint.t)(NoPosition),
-      ColumnRef("location_address", SoQLText.t)(NoPosition),
-      ColumnRef("location_city", SoQLText.t)(NoPosition),
-      ColumnRef("location_state", SoQLText.t)(NoPosition),
-      ColumnRef("location_zip", SoQLText.t)(NoPosition)
-    ))(NoPosition, NoPosition)
-
-    val phoneFc = FunctionCall(SoQLFunctions.Phone.monomorphic.get, Seq(
-      ColumnRef("phone", SoQLText.t)(NoPosition),
-      ColumnRef("phone_type", SoQLText.t)(NoPosition)
-    ))(NoPosition, NoPosition)
-
-    val eqBindings = SoQLFunctions.Eq.parameters.map {
-      case VariableType(name) => name -> SoQLNumber
-      case _ => throw new Exception("Unexpected function signature")
-    }.toMap
-    val eq = MonomorphicFunction(SoQLFunctions.Eq, eqBindings)
-
-    val ptlFc = FunctionCall(SoQLFunctions.PointToLatitude.monomorphic.get,
-      Seq(ColumnRef("location", SoQLPoint.t)(NoPosition)))(NoPosition, NoPosition)
+    val query = "SELECT * WHERE location.latitude = 1.1"
 
     val expectedWhere: CoreExpr[String, SoQLType] =
-      FunctionCall(eq, Seq(ptlFc, NumberLiteral(1.1, SoQLNumber.t)(NoPosition)))(NoPosition, NoPosition)
+      FunctionCall(eqFn, Seq(ptlFc, NumberLiteral(1.1, SoQLNumber.t)(NoPosition)))(NoPosition, NoPosition)
 
     val expectedSelection = com.socrata.soql.collection.OrderedMap(
       ColumnName("a") -> ColumnRef("ai", SoQLText)(NoPosition),
@@ -50,14 +27,83 @@ class QueryParserFuseTest extends TestBase {
       ColumnName("phone") -> phoneFc
     )
 
-    val fuse = Map("location" -> "location", "phone" -> "phone")
     val actual = qp.apply(query, truthColumns, schema, fuse) match {
       case SuccessfulParse(analyses) =>
         val actual = SoQLAnalysisDepositioner(analyses.head)
         actual.selection should be(expectedSelection)
         actual.where should be(Some(expectedWhere))
-      case _: QueryParser.Result =>
-        fail("fail to parse soql")
+      case x: QueryParser.Result =>
+        fail("fail to parse soql: " + x)
+    }
+  }
+
+  test("SELECT * |> SELECT phone, phone_type") {
+    val query = "SELECT * |> SELECT phone, phone_type"
+
+    val expectedSelection = com.socrata.soql.collection.OrderedMap(
+      ColumnName("phone") -> phoneFc
+    )
+
+    val actual = qp.apply(query, truthColumns, schema, fuse) match {
+      case SuccessfulParse(analyses) =>
+        val actual = SoQLAnalysisDepositioner(analyses.head)
+        actual.selection should be(expectedSelection)
+        actual.where should be(None)
+      case x: QueryParser.Result =>
+        fail("fail to parse soql: " + x)
+    }
+  }
+
+  test("SELECT phone, phone_type |> SELECT * LIMIT 100000000") {
+    val query = "SELECT phone, phone_type, a |> SELECT * LIMIT 100000000"
+
+    val expectedSelection = com.socrata.soql.collection.OrderedMap(
+      ColumnName("phone") -> phoneFc,
+      ColumnName("a") -> ColumnRef("ai", SoQLText)(NoPosition)
+    )
+
+    val actual = qp.apply(query, truthColumns, schema, fuse) match {
+      case SuccessfulParse(analyses) =>
+        val actual = SoQLAnalysisDepositioner(analyses.head)
+        actual.selection should be(expectedSelection)
+        actual.where should be(None)
+        actual.limit should be(Some(BigInt(100000000)))
+      case x: QueryParser.Result =>
+        fail("fail to parse soql: " + x)
+    }
+  }
+
+  test("SELECT :*, * | SELECT phone, phone_type, :id -- no fusing") {
+    val query = "SELECT :*, * |> SELECT phone, phone_type, :id"
+
+    val expectedSelection = com.socrata.soql.collection.OrderedMap(
+      ColumnName("phone") -> ColumnRef("phone", SoQLText)(NoPosition),
+      ColumnName("phone_type") -> ColumnRef("phone_type", SoQLText)(NoPosition),
+      ColumnName(":id") -> ColumnRef(":id", SoQLID)(NoPosition)
+    )
+
+    val actual = qp.apply(query, truthColumns, schema, Map.empty) match {
+      case SuccessfulParse(analyses) =>
+        val actual = SoQLAnalysisDepositioner(analyses.head)
+        actual.selection should be(expectedSelection)
+        actual.where should be(None)
+      case x: QueryParser.Result =>
+        fail("fail to parse soql: " + x)
+    }
+  }
+
+  test("SELECT a -- non existent fuse type is ignored") {
+    val query = "SELECT a"
+
+    val expectedSelection = com.socrata.soql.collection.OrderedMap(
+      ColumnName("a") -> ColumnRef("ai", SoQLText)(NoPosition)
+    )
+
+    val actual = qp.apply(query, truthColumns, schema, Map.empty) match {
+      case SuccessfulParse(analyses) =>
+        val actual = SoQLAnalysisDepositioner(analyses.head)
+      case x: QueryParser.Result =>
+        fail("fail to parse soql: " + x)
     }
   }
 }
@@ -66,13 +112,14 @@ object QueryParserFuseTest {
 
   val defaultRowLimit = 20
 
-  val maxRowLimit = 200
+  val maxRowLimit = 200000000
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
 
   val qp = new QueryParser(analyzer, Some(maxRowLimit), defaultRowLimit)
 
   val truthColumns = Map[ColumnName, String](
+    ColumnName(":id") -> ":id",
     ColumnName("a") -> "ai",
     ColumnName("b") -> "bi",
     ColumnName("location") -> "location",
@@ -85,6 +132,7 @@ object QueryParserFuseTest {
   )
 
   val schema = Map[String, SoQLType](
+    ":id" -> SoQLID,
     "ai" -> SoQLText,
     "bi" -> SoQLText,
     "location" -> SoQLPoint,
@@ -95,4 +143,29 @@ object QueryParserFuseTest {
     "phone" -> SoQLText,
     "phone_type" -> SoQLText
   )
+
+  val locationFc = FunctionCall(SoQLFunctions.Location.monomorphic.get, Seq(
+    ColumnRef("location", SoQLPoint.t)(NoPosition),
+    ColumnRef("location_address", SoQLText.t)(NoPosition),
+    ColumnRef("location_city", SoQLText.t)(NoPosition),
+    ColumnRef("location_state", SoQLText.t)(NoPosition),
+    ColumnRef("location_zip", SoQLText.t)(NoPosition)
+  ))(NoPosition, NoPosition)
+
+  val phoneFc = FunctionCall(SoQLFunctions.Phone.monomorphic.get, Seq(
+    ColumnRef("phone", SoQLText.t)(NoPosition),
+    ColumnRef("phone_type", SoQLText.t)(NoPosition)
+  ))(NoPosition, NoPosition)
+
+  val eqBindings = SoQLFunctions.Eq.parameters.map {
+    case VariableType(name) => name -> SoQLNumber
+    case _ => throw new Exception("Unexpected function signature")
+  }.toMap
+
+  val eqFn = MonomorphicFunction(SoQLFunctions.Eq, eqBindings)
+
+  val ptlFc = FunctionCall(SoQLFunctions.PointToLatitude.monomorphic.get,
+    Seq(ColumnRef("location", SoQLPoint.t)(NoPosition)))(NoPosition, NoPosition)
+
+  val fuse = Map("location" -> "location", "phone" -> "phone")
 }


### PR DESCRIPTION
…g does not happen

"select phone, phone_type |> select *" should work
with or w/o --header 'X-Socrata-Fuse-Columns: phone,phone'