### PR TITLE
EN-6168: Don't log the analysis for every query.

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -274,7 +274,8 @@ class QueryResource(secondary: Secondary,
                 val rewritten = RollupScorer.bestRollup(
                   queryRewriter.possibleRewrites(schema, analyzedQuery, rollups).toSeq)
                 val (rollupName, analysis) = rewritten map { x => (Some(x._1), x._2) } getOrElse ((None, analyzedQuery))
-                log.info(s"Rewrote query on dataset $dataset to rollup $rollupName with analysis $analysis")
+                log.info(s"Rewrote query on dataset $dataset to rollup $rollupName")
+                log.debug(s"Rewritten analysis: $analysis")
                 (analysis, rollupName)
               case RollupInfoFetcher.NoSuchDatasetInSecondary =>
                 chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }


### PR DESCRIPTION
This is excessively verbose and we have sufficient other logging
and tooling now to get info on what a queries query is from higher up
the stack.