### PR TITLE
change the logging for rollup info-level failures to not include stac…

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -425,7 +425,7 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLType]) {
     }
 
     analysisMap.foreach {
-      case (rollupName, Failure(e: SoQLException)) => log.info(s"Couldn't parse rollup $rollupName, ignoring: ${e.toString}")
+      case (rollupName, Failure(e: SoQLException)) => log.info(s"Couldn't parse rollup $rollupName, ignoring ${e.getClass.getName}: ${e.getMessage}")
       case (rollupName, Failure(e)) => log.warn(s"Couldn't parse rollup $rollupName due to unexpected failure, ignoring", e)
       case _ =>
     }


### PR DESCRIPTION
…ktraces

this is for EN-5537 but is NOT the fix for the actual larger issue