### PR TITLE
EN-8902 Previously, rollups cannot be used except in the leftmost soq…

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -419,12 +419,7 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLType]) {
 
   def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo], project: Map[String, String]): Map[RollupName, Anal] = {
 
-    def reprojectColumn(cn: ColumnId): ColumnId = {
-      project.get(cn) match {
-        case Some(newName) => newName
-        case None => cn
-      }
-    }
+    def reprojectColumn(cn: ColumnId): ColumnId = project.getOrElse(cn, cn)
 
     val dsContext = prefixedDsContext(schema)
     val rollupMap = rollups.map { r => (r.name, r.soql) }.toMap

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
@@ -26,7 +26,7 @@ class TestQueryRewriter extends TestQueryRewriterBase {
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
   /** Pull in the rollupAnalysis for easier debugging */
-  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
 
   val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -21,7 +21,7 @@ class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
   /** Pull in the rollupAnalysis for easier debugging */
-  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
 
   val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
@@ -28,7 +28,7 @@ class TestRollupScorer extends TestQueryRewriterBase {
     val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
     /** Pull in the rollupAnalysis for easier debugging */
-    val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
+    val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
 
     // validate we don't have any ties, which could confuse things due to having no clear ordering.
     rollupAnalysis.values.map(RollupScorer.scoreRollup(_)).toSet should have size rollups.size


### PR DESCRIPTION
…l in a chain.  This limitation is lifted.