### PR TITLE
EN-14996 Add “Distinct” support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"
-    val soqlStdlib = "2.0.14"
+    val soqlStdlib = "2.1.0"
     val sprayCaching = "1.2.2"
     val typesafeConfig = "1.2.1"
     val metricsJetty = "3.1.0"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -367,7 +367,8 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLType]) {
           // has a limit or offset, but we currently don't.
           ensure(None == r.limit, "mismatch on limit") orElse
           ensure(None == r.offset, "mismatch on offset") orElse
-          ensure(q.search == None, "mismatch on search")
+          ensure(q.search == None, "mismatch on search") orElse
+          ensure(q.distinct == r.distinct, "mismatch on distinct")
 
       mismatch match {
         case None =>

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/caching/SoQLAnalysisDepositioner.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/caching/SoQLAnalysisDepositioner.scala
@@ -9,8 +9,9 @@ import scala.util.parsing.input.NoPosition
 
 object SoQLAnalysisDepositioner {
   def apply[ColumnId,Type](sa: SoQLAnalysis[ColumnId,Type]): SoQLAnalysis[ColumnId,Type] = {
-    val SoQLAnalysis(isGrouped, selection, where, groupBy, having, orderBy, limit, offset, search) = sa
+    val SoQLAnalysis(isGrouped, distinct, selection, where, groupBy, having, orderBy, limit, offset, search) = sa
     SoQLAnalysis(isGrouped = isGrouped,
+                 distinct = distinct,
                  selection = depositionSelection(selection),
                  where = depositionOptExpr(where),
                  groupBy = depositionGroupBys(groupBy),


### PR DESCRIPTION
Just the one in the select level.

SELECT DISTINCT col1, col2, …

not the one inside function

SELECT COUNT(DISTINCT col1)

** DEPLOY soql-postgres-adapter BEFORE query-coordinator **
to avoid service interruption