### PR TITLE
EN-16339 Make chaining/merging work with joins to some degree

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"
-    val soqlStdlib = "2.2.0"
+    val soqlStdlib = "2.2.2"
     val sprayCaching = "1.2.2"
     val typesafeConfig = "1.2.1"
     val metricsJetty = "3.1.0"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -221,11 +221,7 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType], schemaFetcher: SchemaFetcher
   private def soqlMerge(analysesAndColumnIdMap: (Seq[SoQLAnalysis[ColumnName, SoQLType]], Map[QualifiedColumnName, String]))
     : (Seq[SoQLAnalysis[ColumnName, SoQLType]], Map[QualifiedColumnName, String]) = {
     val (analyses, qualColumnIdMap) = analysesAndColumnIdMap
-    if (qualColumnIdMap.keys.exists(_.qualifier.isDefined)) { // Cannot merge if we use more than one tables
-      analysesAndColumnIdMap
-    } else {
-      (SoQLAnalysis.merge(andFn, analyses), qualColumnIdMap)
-    }
+    (SoQLAnalysis.merge(andFn, analyses), qualColumnIdMap)
   }
 
   def apply(selection: Option[String], // scalastyle:ignore parameter.number


### PR DESCRIPTION
This is enough for soqls generated for default views in core server to work.
No need to skip merging whenever there are joins.