### PR TITLE
EN-16423 Fix a long time pre-existing typo in a function that support…

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -223,23 +223,6 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType], schemaFetcher: SchemaFetcher
     val (analyses, qualColumnIdMap) = analysesAndColumnIdMap
     (SoQLAnalysis.merge(andFn, analyses), qualColumnIdMap)
   }
-
-  def apply(selection: Option[String], // scalastyle:ignore parameter.number
-            join: Option[String],
-            where: Option[String],
-            groupBy: Option[String],
-            having: Option[String],
-            orderBy: Option[String],
-            limit: Option[String],
-            offset: Option[String],
-            search: Option[String],
-            columnIdMapping: Map[ColumnName, String],
-            schema: Map[String, SoQLType],
-            selectedSecondaryInstanceBase: RequestBuilder,
-            fuseMap: Map[String, String]): Result = {
-    val query = fullQuery(selection, join, where, groupBy, having, orderBy, limit, offset, search)
-    apply(query, columnIdMapping, schema, selectedSecondaryInstanceBase, fuseMap)
-  }
 }
 
 object QueryParser extends Logging {
@@ -274,28 +257,6 @@ object QueryParser extends Logging {
           OrderedMap(knownColumnIdMapping.mapValues(rawSchema).toSeq.sortBy(_._1): _*)
       }
     }
-
-  private def fullQuery(selection: Option[String],
-                        join: Option[String],
-                        where: Option[String],
-                        groupBy: Option[String],
-                        having: Option[String],
-                        orderBy: Option[String],
-                        limit: Option[String],
-                        offset: Option[String],
-                        search: Option[String]): String = {
-    val sb = new StringBuilder
-    sb.append(selection.map( "SELECT " + _).getOrElse("SELECT *"))
-    sb.append(join.map(" JOIN " + _).getOrElse(""))
-    sb.append(where.map(" WHERE " + _).getOrElse(""))
-    sb.append(groupBy.map(" GROUP BY " + _).getOrElse(""))
-    sb.append(having.map(" HAVING " + _).getOrElse(""))
-    sb.append(orderBy.map(" ORDER BY " + _).getOrElse(""))
-    sb.append(limit.map(" LIMIT " + _).getOrElse(""))
-    sb.append(offset.map(" OFFSET " + _).getOrElse(""))
-    sb.append(search.map(s => "SEARCH %s".format(Expression.escapeString(s))).getOrElse(""))
-    sb.result()
-  }
 
   // And function is used for chain SoQL merge.
   private val andFn = SoQLFunctions.And.monomorphic.get

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -225,6 +225,7 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType], schemaFetcher: SchemaFetcher
   }
 
   def apply(selection: Option[String], // scalastyle:ignore parameter.number
+            join: Option[String],
             where: Option[String],
             groupBy: Option[String],
             having: Option[String],
@@ -236,7 +237,7 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType], schemaFetcher: SchemaFetcher
             schema: Map[String, SoQLType],
             selectedSecondaryInstanceBase: RequestBuilder,
             fuseMap: Map[String, String]): Result = {
-    val query = fullQuery(selection, where, groupBy, having, orderBy, limit, offset, search)
+    val query = fullQuery(selection, join, where, groupBy, having, orderBy, limit, offset, search)
     apply(query, columnIdMapping, schema, selectedSecondaryInstanceBase, fuseMap)
   }
 }
@@ -274,23 +275,25 @@ object QueryParser extends Logging {
       }
     }
 
-  private def fullQuery(selection : Option[String],
-                        where : Option[String],
-                        groupBy : Option[String],
-                        having : Option[String],
-                        orderBy : Option[String],
-                        limit : Option[String],
-                        offset : Option[String],
-                        search : Option[String]): String = {
+  private def fullQuery(selection: Option[String],
+                        join: Option[String],
+                        where: Option[String],
+                        groupBy: Option[String],
+                        having: Option[String],
+                        orderBy: Option[String],
+                        limit: Option[String],
+                        offset: Option[String],
+                        search: Option[String]): String = {
     val sb = new StringBuilder
     sb.append(selection.map( "SELECT " + _).getOrElse("SELECT *"))
+    sb.append(join.map(" JOIN " + _).getOrElse(""))
     sb.append(where.map(" WHERE " + _).getOrElse(""))
-    sb.append(where.map(" GROUP BY " + _).getOrElse(""))
-    sb.append(where.map(" HAVING " + _).getOrElse(""))
-    sb.append(where.map(" ORDER BY " + _).getOrElse(""))
-    sb.append(where.map(" LIMIT " + _).getOrElse(""))
-    sb.append(where.map(" OFFSET " + _).getOrElse(""))
-    sb.append(where.map(s => "SEARCH %s".format(Expression.escapeString(s))).getOrElse(""))
+    sb.append(groupBy.map(" GROUP BY " + _).getOrElse(""))
+    sb.append(having.map(" HAVING " + _).getOrElse(""))
+    sb.append(orderBy.map(" ORDER BY " + _).getOrElse(""))
+    sb.append(limit.map(" LIMIT " + _).getOrElse(""))
+    sb.append(offset.map(" OFFSET " + _).getOrElse(""))
+    sb.append(search.map(s => "SEARCH %s".format(Expression.escapeString(s))).getOrElse(""))
     sb.result()
   }
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -81,19 +81,7 @@ class QueryResource(secondary: Secondary,
                                             .map(parseFuseColumnMap(_))
                                             .getOrElse(Map.empty)
 
-      val query = Option(servReq.getParameter("q")).map(Left(_)).getOrElse {
-        Right(FragmentedQuery(
-          select = Option(servReq.getParameter("select")),
-          join = Option(servReq.getParameter("join")),
-          where = Option(servReq.getParameter("where")),
-          group = Option(servReq.getParameter("group")),
-          having = Option(servReq.getParameter("having")),
-          search = Option(servReq.getParameter("search")),
-          order = Option(servReq.getParameter("order")),
-          limit = Option(servReq.getParameter(qpLimit)),
-          offset = Option(servReq.getParameter("offset"))
-        ))
-      }
+      val query = servReq.getParameter("q")
 
       val rowCount = Option(servReq.getParameter("rowCount"))
       val copy = Option(servReq.getParameter("copy"))
@@ -136,26 +124,8 @@ class QueryResource(secondary: Secondary,
         log.debug("Base URI: " + base.url)
 
         def analyzeRequest(schema: Versioned[Schema], isFresh: Boolean): Either[QueryRetryState, Versioned[(Schema, Seq[SoQLAnalysis[String, SoQLType]])]] = {
-          val parsedQuery = query match {
-            case Left(q) =>
-              queryParser(q, columnIdMap, schema.payload.schema, base, fuseMap)
-            case Right(fq) =>
-              queryParser(
-                selection = fq.select,
-                join = fq.join,
-                where = fq.where,
-                groupBy = fq.group,
-                having = fq.having,
-                orderBy = fq.order,
-                limit = fq.limit,
-                offset = fq.offset,
-                search = fq.search,
-                columnIdMapping = columnIdMap,
-                schema = schema.payload.schema,
-                base,
-                fuseMap = fuseMap
-              )
-          }
+
+          val parsedQuery = queryParser(query, columnIdMap, schema.payload.schema, base, fuseMap)
 
           parsedQuery match {
             case QueryParser.SuccessfulParse(analysis) =>

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -84,6 +84,7 @@ class QueryResource(secondary: Secondary,
       val query = Option(servReq.getParameter("q")).map(Left(_)).getOrElse {
         Right(FragmentedQuery(
           select = Option(servReq.getParameter("select")),
+          join = Option(servReq.getParameter("join")),
           where = Option(servReq.getParameter("where")),
           group = Option(servReq.getParameter("group")),
           having = Option(servReq.getParameter("having")),
@@ -141,6 +142,7 @@ class QueryResource(secondary: Secondary,
             case Right(fq) =>
               queryParser(
                 selection = fq.select,
+                join = fq.join,
                 where = fq.where,
                 groupBy = fq.group,
                 having = fq.having,

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
@@ -120,16 +120,6 @@ trait QueryService {
     Json(error)
   }
 
-  case class FragmentedQuery(select: Option[String],
-                             join: Option[String],
-                             where: Option[String],
-                             group: Option[String],
-                             having: Option[String],
-                             search: Option[String],
-                             order: Option[String],
-                             limit: Option[String],
-                             offset: Option[String])
-
   case class FinishRequest(response: HttpResponse) extends ControlThrowable
 
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
@@ -121,6 +121,7 @@ trait QueryService {
   }
 
   case class FragmentedQuery(select: Option[String],
+                             join: Option[String],
                              where: Option[String],
                              group: Option[String],
                              having: Option[String],


### PR DESCRIPTION
…s fragmented SoQLs.

The typo didn’t cause problem because it isn’t really used.  But I would like that fixed to please my eyes.