### PR TITLE
EN-19151: Support query rewrite on count(column).

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"
-    val soqlStdlib = "2.6.2"
+    val soqlStdlib = "2.7.1"
     val sprayCaching = "1.2.2"
     val typesafeConfig = "1.2.1"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
A count on a specific column is the number of non-null values, which can be
added together with a simple sum just like count(*).