### PR TITLE
Bump soql-reference to make ‘partition by’ required when the followin…

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"
-    val soqlStdlib = "2.7.1"
+    val soqlStdlib = "2.7.2"
     val sprayCaching = "1.2.2"
     val typesafeConfig = "1.2.1"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
…g list is not empty.