### PR TITLE
EN-19155: Bump soqlStdlib to 2.9.1 to support new geo functions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.1"
     val socrataThirdpartyUtils = "4.0.1"
     val socrataUtils = "0.10.0"
-    val soqlStdlib = "2.9.0"
+    val soqlStdlib = "2.9.1"
     val sprayCaching = "1.2.2"
     val typesafeConfig = "1.2.1"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
To support definitions added by: https://github.com/socrata-platform/soql-reference/pull/92