### PR TITLE
EN-20877 Fix create cache table race issue.

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/caching/cache/postgresql/PostgresqlCacheSchema.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/caching/cache/postgresql/PostgresqlCacheSchema.scala
@@ -72,7 +72,7 @@ object PostgresqlCacheSchema {
           for (ds <- dataset) {
             val dataTableName = dataTable(ds)
             if (!exists(dataTableName)) {
-              stmt.execute(s"create table ${dataTableName} (cache_id bigint not null, chunknum int not null, data bytea not null, primary key(cache_id, chunknum))")
+              stmt.execute(s"create table if not exists ${dataTableName} (cache_id bigint not null, chunknum int not null, data bytea not null, primary key(cache_id, chunknum))")
             }
           }
         }


### PR DESCRIPTION
Exception in thread "Cache thread" org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
  Detail: Key (typname, typnamespace)=(cache_alpha_103197_data, 2200) already exists.