### PR TITLE
EN-22044: Explicit use of local.dev.socrata.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 query-coordinator-assembly.jar
 /.idea/
 /.idea_modules/
-configs/local-query-coordinator.conf
+configs/local*.conf
 local-query-coordinator.conf
 /**/target/

--- a/configs/application.conf
+++ b/configs/application.conf
@@ -1,6 +1,6 @@
 # Sensible defaults for a development environment
-include "sample-query-coordinator.conf"
+include "sample.conf"
 
 # This file is .gitignored; you can create it and make
 # any changes you like there.
-include "local-query-coordinator.conf"
+include "local.conf"

--- a/configs/sample-query-coordinator.conf
+++ b/configs/sample-query-coordinator.conf
@@ -1,8 +1,0 @@
-com.socrata.query-coordinator {
-  curator.ensemble = ["local.dev.socrata.net:2181"]
-  network.port = 6030
-  service-advertisement.address = "local.dev.socrata.net"
-  log4j {
-    logger.com.socrata = INFO
-  }
-}

--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -1,0 +1,12 @@
+# use local.dev.socrata.net to support solo which resolves to 127.0.0.1
+common-host = "local.dev.socrata.net"
+common-zk-ensemble = ["local.dev.socrata.net:2181"]
+
+com.socrata.query-coordinator {
+  curator.ensemble = ${common-zk-ensemble}
+  network.port = 6030
+  service-advertisement.address = ${common-host}
+  log4j {
+    logger.com.socrata = INFO
+  }
+}

--- a/query-coordinator/src/main/resources/reference.conf
+++ b/query-coordinator/src/main/resources/reference.conf
@@ -28,7 +28,6 @@ com.socrata.query-coordinator {
   service-advertisement {
     service-base-path = "/services"
     name = query-coordinator
-    address = "localhost"
   }
 
   liveness-check {


### PR DESCRIPTION
Clearly comment that it was for solo (becaus I was confused).
Also, a little bit of config renaming to match spandex based
 off of code reviews there.