### PR TITLE
EN-27867 Longitude is incorrectly mapped in QC compound type fuser ca…

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuser.scala
@@ -208,7 +208,7 @@ class CompoundTypeFuser(fuseBase: Map[String, String]) extends SoQLRewrite with 
                 Some(FunctionCall(SoQLFunctions.PointToLatitude.name, args)(NoPosition, NoPosition))
               case "longitude" =>
                 val args = Seq(ColumnOrAliasRef(NoQualifier, ColumnName(s"${name.name}"))(NoPosition))
-                Some(FunctionCall(SoQLFunctions.PointToLatitude.name, args)(NoPosition, NoPosition))
+                Some(FunctionCall(SoQLFunctions.PointToLongitude.name, args)(NoPosition, NoPosition))
               case "human_address" =>
                 val args = Seq("address", "city", "state", "zip")
                   .map(subProp => ColumnOrAliasRef(NoQualifier, ColumnName(s"${name.name}_$subProp"))(NoPosition))


### PR DESCRIPTION
…used by typo.