### PR TITLE
EN-40314: Don't rewrite window functions.

### DIFF
--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestBase.scala
@@ -9,7 +9,7 @@ import org.apache.log4j.PropertyConfigurator
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-abstract class TestBase extends FunSuite  with Matchers with ScalaCheckPropertyChecks {
+abstract class TestBase extends FunSuite  with Matchers with ScalaCheckPropertyChecks with BeforeAndAfterAll {
   val config: Config = ConfigFactory.load().getConfig("com.socrata.query-coordinator")
 
   PropertyConfigurator.configure(Propertizer("log4j", config.getConfig("log4j")))

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
@@ -1,0 +1,66 @@
+package com.socrata.querycoordinator
+
+import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.querycoordinator.util.Join.toAnalysisContext
+import com.socrata.querycoordinator.util.Join.mapIgnoringQualifier
+import com.socrata.soql.SoQLAnalysis
+import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.types.SoQLType
+
+class TestQueryRewriterWindowFunction extends TestQueryRewriterBase {
+  /** Each rollup here is defined by:
+    * - a name
+    * - a soql statement.  Note this must be the mapped statement,
+    * i.e. non-system columns prefixed by an _, and backtick escaped
+    * - a Seq of the soql types for each column in the rollup selection
+    */
+  val rollups: Seq[(String, String)] = Seq(
+    ("r1", "SELECT `_crim-typ3`, `:wido-ward`, avg(`_dxyz-num1`) over (partition by `_crim-typ3`)"),
+  )
+
+  val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
+
+  /** Pull in the rollupAnalysis for easier debugging */
+  val rollupAnalysis: Map[RollupName, Anal] = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
+
+  val rollupRawSchemas = rollupAnalysis.mapValues { analysis: Anal =>
+    analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>
+      rewriter.rollupColumnId(idx) -> expr.typ
+    }.toMap
+  }
+
+  /** Analyze a "fake" query that has the rollup table column names in, so we
+    * can use it to compare  with the rewritten one in assertions.
+    */
+  def analyzeRewrittenQuery(rollupName: String, q: String): SoQLAnalysis[String, SoQLType] = {
+    val rewrittenRawSchema = rollupRawSchemas(rollupName)
+
+    val rollupNoopColumnNameMap = rewrittenRawSchema.map { case (k, _) => ColumnName(k) -> k }
+
+    val rollupDsContext = QueryParser.dsContext(rollupNoopColumnNameMap, rewrittenRawSchema)
+
+    val rewrittenQueryAnalysis = analyzer.analyzeUnchainedQuery(q)(toAnalysisContext(rollupDsContext)).mapColumnIds(mapIgnoringQualifier(rollupNoopColumnNameMap))
+    rewrittenQueryAnalysis
+  }
+
+  test("do not map window functions with different where") {
+    val q = "SELECT crime_type, ward, avg(number1) over (partition by crime_type) WHERE ward = 23"
+    val queryAnalysis = analyzeQuery(q)
+
+    val rewrites = rewriter.possibleRewrites(queryAnalysis, rollupAnalysis)
+
+    rewrites should have size 0
+  }
+
+  // We logically should be able to rewrite this and several other cases, but for simplicity the current code takes
+  // a blanket "do not rewrite if there is a window function" approach.  This test is documentation of what we
+  // _could_ enhance the code to rewrite.
+  test("doesn't map window functions with no where and different selection (logically could succeed, but not implemented)") {
+    val q = "SELECT crime_type, avg(number1) over (partition by crime_type)"
+    val queryAnalysis = analyzeQuery(q)
+
+    val rewrites = rewriter.possibleRewrites(queryAnalysis, rollupAnalysis)
+
+    rewrites should have size 0
+  }
+}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
@@ -1,35 +1,34 @@
 package com.socrata.querycoordinator
 
 class TestRollupScorer extends TestQueryRewriterBase {
+  /** Each rollup here is defined by:
+    * - a name
+    * - a soql statement.  Note this must be the mapped statement,
+    * i.e. non-system columns prefixed by an _, and backtick escaped
+    * - a Seq of the soql types for each column in the rollup selection
+    *
+    * They need to be ORDERED in "best" to worst order and all have distinct scores to ensure there are
+    * no ties.
+    */
+  val rollups = Seq(
+    ("r1", "SELECT sum(`_dxyz-num1`)"),
+    ("r2", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL AND `:wido-ward` = 8 GROUP BY `_dxyz-num1` "),
+    ("r3", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
+    ("r4", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
+    ("r5", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) GROUP BY `_dxyz-num1`"),
+    ("r6", "SELECT `:wido-ward`, min(`_dxyz-num1`), max(`_dxyz-num1`), sum(`_dxyz-num1`), count(*) GROUP BY `:wido-ward`"),
+    ("r7", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`"),
+    ("r8", "SELECT `:wido-ward`, `_crim-typ3`, count(*), `_dxyz-num1`, `_crim-date` GROUP BY `:wido-ward`, `_crim-typ3`, `_dxyz-num1`, `_crim-date`"),
+    ("r9", "SELECT `:wido-ward`"),
+    ("ra", "SELECT `:wido-ward`, `_crim-typ3`")
+  )
+
+  val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
+
+  /** Pull in the rollupAnalysis for easier debugging */
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
 
   test("rollup scoring") {
-    /** Each rollup here is defined by:
-      * - a name
-      * - a soql statement.  Note this must be the mapped statement,
-      * i.e. non-system columns prefixed by an _, and backtick escaped
-      * - a Seq of the soql types for each column in the rollup selection
-      *
-      * They need to be ORDERED in "best" to worst order and all have distinct scores to ensure there are
-      * no ties.
-      */
-    val rollups = Seq(
-      ("r1", "SELECT sum(`_dxyz-num1`)"),
-      ("r2", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL AND `:wido-ward` = 8 GROUP BY `_dxyz-num1` "),
-      ("r3", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_dxyz-num1` = 1 AND `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
-      ("r4", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) WHERE `_crim-date` IS NOT NULL GROUP BY `_dxyz-num1`"),
-      ("r5", "SELECT `_dxyz-num1`, count(`_dxyz-num1`) GROUP BY `_dxyz-num1`"),
-      ("r6", "SELECT `:wido-ward`, min(`_dxyz-num1`), max(`_dxyz-num1`), sum(`_dxyz-num1`), count(*) GROUP BY `:wido-ward`"),
-      ("r7", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`"),
-      ("r8", "SELECT `:wido-ward`, `_crim-typ3`, count(*), `_dxyz-num1`, `_crim-date` GROUP BY `:wido-ward`, `_crim-typ3`, `_dxyz-num1`, `_crim-date`"),
-      ("r9", "SELECT `:wido-ward`"),
-      ("ra", "SELECT `:wido-ward`, `_crim-typ3`")
-    )
-
-    val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
-
-    /** Pull in the rollupAnalysis for easier debugging */
-    val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
-
     // validate we don't have any ties, which could confuse things due to having no clear ordering.
     rollupAnalysis.values.map(RollupScorer.scoreRollup(_)).toSet should have size rollups.size
 


### PR DESCRIPTION
Window functions run after where / group by / having so can't be
rewritten in isolation.  We could still rewrite a query with a
window function in if the other clauses all match, however that
requires coordination between expression mapping and mapping other
clauses at a higher level that isn't implemented, so for now we
just forbid it entirely to avoid incorrect rewrites.