### PR TITLE
EN-24494: Bump soql-reference so that

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "2.15.0"
+    val soqlStdlib = "2.16.1"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"


### PR DESCRIPTION
it does not merge chained soql if there is search and grouping any more after the new semantics of search (application to the output schema instead of the input schema)