### PR TITLE
bump soqlstdlib dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "3.3.4"
+    val soqlStdlib = "3.3.5"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"


### PR DESCRIPTION
Add support for the new functions in the new SoQL Standard Lib:
`regr_slope`
`regr_intercept`
`regr_r2`
`ln`