### PR TITLE
Update for changes in soql-stdlib

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "3.3.5"
+    val soqlStdlib = "3.4.0"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"


### PR DESCRIPTION
* New error cases leftover from the introduction of `single_row`
* Joins have been slightly restructured
* Bail on join functions (since they should have been eliminated in core)