### PR TITLE
EN-47916: Be able to preserve parentheses in compound queries

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "3.7.1"
+    val soqlStdlib = "3.8.0"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -300,14 +300,14 @@ class QueryResource(secondary: Secondary,
             (analyzedQuery, Seq.empty)
           } else {
             analyzedQuery match {
-              case PipeQuery(l, r) =>
+              case PipeQuery(l, r, inParen) =>
                 val (nl, rollupLeft) = possiblyRewriteOneAnalysisInQuery(schema, l)
-                (PipeQuery(nl, r), rollupLeft)
+                (PipeQuery(nl, r, inParen), rollupLeft)
               case Compound(_, _, _) => // TODO: Support rollups in unions
                 (analyzedQuery, Seq.empty)
-              case Leaf(analysis) if analysis.joins.nonEmpty =>
+              case Leaf(analysis, _) if analysis.joins.nonEmpty =>
                 (analyzedQuery, Seq.empty)
-              case Leaf(analysis) =>
+              case Leaf(analysis, _) =>
                 val (schemaFrom, datasetOrResourceName) = analysis.from match {
                   case Some(TableName(TableName.This, _)) =>
                     (schema, Left(dataset))

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/BinaryTreeHelper.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/BinaryTreeHelper.scala
@@ -10,23 +10,23 @@ object BinaryTreeHelper {
    */
   def replace[T <: AnyRef](analyses: BinaryTree[T], a: T, b: T): BinaryTree[T] = {
     analyses match {
-      case Compound(op, l, r) =>
+      case c@Compound(op, l, r) =>
         val nl = replace(l, a, b)
         val nr = replace(r, a, b)
-        Compound(op, left = nl, right = nr)
-      case Leaf(analysis) =>
-        if (analysis.eq(a)) Leaf(b) // object reference comparison
+        Compound(op, left = nl, right = nr, c.inParen)
+      case Leaf(analysis, inParen) =>
+        if (analysis.eq(a)) Leaf(b, inParen) // object reference comparison
         else analyses
     }
   }
 
   def outerMostAnalyses[T](analyses: BinaryTree[SoQLAnalysis[T, SoQLType]], seq: Seq[SoQLAnalysis[T, SoQLType]] = Seq.empty): Seq[SoQLAnalysis[T, SoQLType]] = {
     analyses match {
-      case PipeQuery(_, r) =>
+      case PipeQuery(_, r, _) =>
         outerMostAnalyses(r, seq)
       case Compound(_, l, r) =>
         outerMostAnalyses(l, seq) ++ outerMostAnalyses(r, seq)
-      case Leaf(analysis) =>
+      case Leaf(analysis, _) =>
         seq :+ analysis
     }
   }


### PR DESCRIPTION
Previously, parentheses can only influence the left, right structure of binary tree.  This doesn't work well with set operations that are different in precedence.