### PR TITLE
use v3.11.2 of soqlstdlib

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "3.11.0"
+    val soqlStdlib = "3.11.2"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"


### PR DESCRIPTION
Before:
v3.11.0

After:
v3.11.2

Supporting new SoQL Functions LEAD and LAG