### PR TITLE
EN-32486: Fix datetrunc logic to work with the context variable approach

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/datetime/NowAnalyzer.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/datetime/NowAnalyzer.scala
@@ -46,14 +46,14 @@ class NowAnalyzer[A, B](selects: BinaryTree[SoQLAnalysis[A, B]]) {
         if getUtcDateFn.name == GetUtcDate.name &&
            truncateDateFns.contains(truncateFn.name) &&
            toFloatingTimestampFn.name == ToFloatingTimestamp.name =>
-        nowAtTimeZone(truncateFn)
+        nowTruncatedAtUtc(truncateFn)
       case FunctionCall(MonomorphicFunction(truncateFn, _), Seq(
              FunctionCall(MonomorphicFunction(getUtcDateFn, _), _, _, _)), _, _)
         if getUtcDateFn.name == GetUtcDate.name &&
           truncateDateFns.contains(truncateFn.name) =>
-        nowAtTimeZone(truncateFn)
+        nowTruncatedAtUtc(truncateFn)
       case FunctionCall(MonomorphicFunction(fn, _), _, _, _) if fn.name == GetUtcDate.name =>
-        nowAtTimeZone(GetUtcDate)
+        nowTruncatedAtUtc(GetUtcDate)
       case FunctionCall(_, args, filter, _) =>
         args.flatMap(collectNow) ++ filter.toSeq.flatMap(collectNow)
       case _ =>
@@ -64,7 +64,7 @@ class NowAnalyzer[A, B](selects: BinaryTree[SoQLAnalysis[A, B]]) {
   /**
     * return now in datetime with year, month, day or second precision depending on the date_trunc/get_utc_date function
     */
-  private def nowAtTimeZone(dateTrunc: com.socrata.soql.functions.Function[_]): Seq[DateTime] = {
+  private def nowTruncatedAtUtc(dateTrunc: com.socrata.soql.functions.Function[_]): Seq[DateTime] = {
     val now = new DateTime(DateTimeZone.UTC)
     val nowTruncated = dateTrunc match {
       case GetUtcDate =>

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryParserTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryParserTest.scala
@@ -10,7 +10,7 @@ import com.socrata.soql.functions._
 import com.socrata.soql.parsing.SoQLPosition
 import com.socrata.soql.{Leaf, SoQLAnalyzer}
 import com.socrata.soql.typed.{ColumnRef, FunctionCall, StringLiteral}
-import com.socrata.soql.types.{SoQLText, SoQLType}
+import com.socrata.soql.types.{SoQLFixedTimestamp, SoQLFloatingTimestamp, SoQLText, SoQLType}
 
 import scala.util.parsing.input.NoPosition
 
@@ -23,7 +23,9 @@ class QueryParserTest extends TestBase {
     val starPos = query.indexOf("*") + 1
     val expected = com.socrata.soql.collection.OrderedMap(
       ColumnName("a") -> ColumnRef(NoQualifier, "ai", SoQLText)(new SoQLPosition(1, starPos, query, 0)),
-      ColumnName("b") -> ColumnRef(NoQualifier, "bi", SoQLText)(new SoQLPosition(1, starPos, query, 0))
+      ColumnName("b") -> ColumnRef(NoQualifier, "bi", SoQLText)(new SoQLPosition(1, starPos, query, 0)),
+      ColumnName("d") -> ColumnRef(NoQualifier, "di", SoQLFloatingTimestamp)(new SoQLPosition(1, starPos, query, 0)),
+      ColumnName("dz") -> ColumnRef(NoQualifier, "dzi", SoQLFixedTimestamp)(new SoQLPosition(1, starPos, query, 0))
     )
     val actual = qp.apply(query, truthColumns, upToDateSchema, fakeRequestBuilder) match {
       case SuccessfulParse(analyses, _) => analyses.asLeaf.get.selection
@@ -132,9 +134,11 @@ object QueryParserTest {
 
   val qp = new QueryParser(analyzer, FakeSchemaFetcher, Some(maxRowLimit), defaultRowLimit)
 
-  val truthColumns = Map[ColumnName, String](ColumnName("a") -> "ai", ColumnName("b") -> "bi")
+  val truthColumns = Map[ColumnName, String](ColumnName("a") -> "ai", ColumnName("b") -> "bi",
+    ColumnName("d") -> "di", ColumnName("dz") -> "dzi")
 
-  val upToDateSchema = Map[String, SoQLType]("ai" -> SoQLText, "bi" -> SoQLText)
+  val upToDateSchema = Map[String, SoQLType]("ai" -> SoQLText, "bi" -> SoQLText,
+    "di" -> SoQLFloatingTimestamp, "dzi" -> SoQLFixedTimestamp)
 
   val outdatedSchema = Map[String, SoQLType]("ai" -> SoQLText) // Does not have "column bi"
 

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/datetime/NowAnalyzerTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/datetime/NowAnalyzerTest.scala
@@ -1,0 +1,78 @@
+package com.socrata.querycoordinator.datetime
+
+import com.socrata.querycoordinator.QueryParser.SuccessfulParse
+import com.socrata.querycoordinator.TestBase
+import org.joda.time.{DateTime, DateTimeZone}
+
+
+class NowAnalyzerTest  extends TestBase {
+
+  import com.socrata.querycoordinator.QueryParserTest._
+
+  test("basic get_utc_date() returns now without ms") {
+    val query = "SELECT a WHERE get_utc_date() is not null"
+    val actual = qp.apply(query, truthColumns, upToDateSchema, fakeRequestBuilder, merged = false)
+    actual shouldBe a[SuccessfulParse]
+
+    val SuccessfulParse(analyses, _) = actual
+    val nowWithMs = DateTime.now(DateTimeZone.UTC)
+    val now = nowWithMs.minusMillis(nowWithMs.millisOfSecond.get)
+    val result = (new NowAnalyzer(analyses).getNow()).get
+    result.isBefore(now) shouldBe (false)
+    result.millisOfSecond().get shouldBe (0)
+  }
+
+  test("get_utc_date() works with truncation and timezone translation") {
+    val query = "SELECT date_trunc_ym(to_floating_timestamp(get_utc_date(), 'US/Pacific')) WHERE d > date_trunc_y(to_floating_timestamp(get_utc_date(), 'US/Pacific'))"
+    val actual = qp.apply(query, truthColumns, upToDateSchema, fakeRequestBuilder, merged = false)
+    actual shouldBe a[SuccessfulParse]
+
+    val SuccessfulParse(analyses, _) = actual
+    val nowWithMs = DateTime.now(DateTimeZone.UTC)
+    val now = nowWithMs.minusMillis(nowWithMs.millisOfSecond().get)
+    val nowWODay = now.minusDays(now.dayOfMonth().get - 1).minusSeconds(now.secondOfDay().get())
+    val result = (new NowAnalyzer(analyses).getNow()).get
+    result shouldBe (nowWODay)
+  }
+
+  test("get_utc_date() works with year truncation in order by") {
+    val query = "SELECT d ORDER BY date_trunc_y(to_floating_timestamp(get_utc_date(), 'US/Eastern'))"
+    val actual = qp.apply(query, truthColumns, upToDateSchema, fakeRequestBuilder, merged = false)
+    actual shouldBe a[SuccessfulParse]
+
+    val SuccessfulParse(analyses, _) = actual
+    val nowWithMs = DateTime.now(DateTimeZone.UTC)
+    val now = nowWithMs.minusMillis(nowWithMs.millisOfSecond().get)
+    val nowWODay = now.minusMonths(now.monthOfYear.get - 1).minusDays(now.dayOfMonth.get - 1).minusSeconds(now.secondOfDay.get)
+    val result = (new NowAnalyzer(analyses).getNow).get
+    result.getMonthOfYear shouldBe(1)
+    result.getDayOfYear shouldBe(1)
+    result.getHourOfDay shouldBe(0)
+    result.getMinuteOfHour shouldBe(0)
+    result.getSecondOfMinute shouldBe(0)
+    val utc = result.withZone(DateTimeZone.UTC)
+    result shouldBe(nowWODay)
+    result shouldBe(utc)
+  }
+
+  test("get_utc_date() works with year truncation of fixed_timestamp") {
+    val query = "SELECT datez_trunc_y(get_utc_date())"
+    val actual = qp.apply(query, truthColumns, upToDateSchema, fakeRequestBuilder, merged = false)
+    actual shouldBe a[SuccessfulParse]
+
+    val SuccessfulParse(analyses, _) = actual
+    val nowWithMs = DateTime.now(DateTimeZone.UTC)
+    val now = nowWithMs.minusMillis(nowWithMs.millisOfSecond().get)
+    val nowWODay = now.minusMonths(now.monthOfYear.get - 1).minusDays(now.dayOfMonth.get - 1).minusSeconds(now.secondOfDay.get)
+    val result = (new NowAnalyzer(analyses).getNow).get
+    result.getMonthOfYear shouldBe(1)
+    result.getDayOfYear shouldBe(1)
+    result.getHourOfDay shouldBe(0)
+    result.getMinuteOfHour shouldBe(0)
+    result.getSecondOfMinute shouldBe(0)
+
+    val utc = result.withZone(DateTimeZone.UTC)
+    result shouldBe (nowWODay)
+    result shouldBe(utc)
+  }
+}


### PR DESCRIPTION
Which is simpler and always uses UTC.

The datetrunc logic only worked for timestamp literal approach