### PR TITLE
EN-50984: Queries without explicit group by do not use rollups

### DIFF
--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -19,7 +19,9 @@ class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
   val rollups = Seq(
     ("r_ymd", "SELECT date_trunc_ymd(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ymd(`_crim-date`), `:wido-ward`"),
     ("r_ym", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`"),
-    ("r_y", "SELECT date_trunc_y(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_y(`_crim-date`), `:wido-ward`")
+    ("r_y", "SELECT date_trunc_y(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_y(`_crim-date`), `:wido-ward`"),
+    ("r_sca_ymd", "SELECT date_trunc_ymd(`_crim-date`), sum(`_dxyz-num1`), count(`_dxyz-num1`), avg(`_dxyz-num1`) GROUP BY date_trunc_ymd(`_crim-date`)"),
+    ("r_arithmetic_outside_aggregate_ymd", "SELECT date_trunc_ymd(`_crim-date`), sum(`_dxyz-num1`)*60, count(`_dxyz-num1`), avg(`_dxyz-num1`), `:wido-ward` GROUP BY date_trunc_ymd(`_crim-date`),`:wido-ward`")
   )
 
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncLtGte.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncLtGte.scala
@@ -1,7 +1,8 @@
 package com.socrata.querycoordinator
 
 import com.socrata.soql.functions.SoQLFunctions._
-import com.socrata.soql.types.SoQLFloatingTimestamp
+import com.socrata.soql.typed
+import com.socrata.soql.types.{SoQLFloatingTimestamp, SoQLType}
 
 class TestQueryRewriterDateTruncLtGte extends TestQueryRewriterDateTruncBase {
   val rewrittenQueryRymd = "SELECT c2 as ward, coalesce(sum(c3), 0) as count WHERE c1 >= '2011-03-08' AND c1 < '2019-08-02' GROUP BY c2"
@@ -90,5 +91,41 @@ class TestQueryRewriterDateTruncLtGte extends TestQueryRewriterDateTruncBase {
     rewriter.truncatedTo(ts("2012-05-09T00:10:00")) should be(None)
     rewriter.truncatedTo(ts("2012-05-09T00:00:02")) should be(None)
     rewriter.truncatedTo(ts("2012-05-09T00:00:00.001")) should be(None)
+  }
+
+  test("rewrite sum / count with implicit group by in query") {
+    val q = "SELECT sum(number1)/count(number1) as avg WHERE crime_date >= '2011-01-01' AND crime_date < '2019-01-01'"
+    val rq = "SELECT sum(c2) /  coalesce(sum(c3), 0) as avg WHERE c1 >= '2011-01-01' AND c1 < '2019-01-01'"
+    val ra = analyzeRewrittenQuery("r_sca_ymd", rq)
+    val rewrites = rewritesFor(q)
+    rewrites should have size 1
+    rewrites should contain key "r_sca_ymd"
+    val rewrite = rewrites("r_sca_ymd")
+    rewrite should equal(ra)
+  }
+
+  test("negative test to demonstrate rewritten query is wrong when SELECT contains arithmetic outside aggregate function") {
+    val q = "SELECT sum(number1) * 60 as sumx60 WHERE crime_date >= '2011-01-01' AND crime_date < '2019-01-01' GROUP BY ward"
+    val rewrites = rewritesFor(q)
+    rewrites should have size 1
+    rewrites should contain key "r_arithmetic_outside_aggregate_ymd"
+    val rewrite = rewrites("r_arithmetic_outside_aggregate_ymd")
+    rewrite.selection should have size 1
+    rewrite.groupBys should have size 1
+    assertThrows[Exception] {
+      rewrite.selection.values.head match {
+        case _: typed.ColumnRef[_, SoQLType] =>
+          // wrong rewrite: SELECT c2 as sumx60 WHERE c1 >= '2011-01-01' AND c1 < '2019-01-01' GROUP BY c5
+          // correct rewrite should be: SELECT sum(c2) as sumx60 WHERE c1 >= '2011-01-01' AND c1 < '2019-01-01' GROUP BY c5
+          throw new Exception("SELECT field GROUP BY g1... is wrong")
+        case _ =>
+      }
+    }
+  }
+
+  test("does not support avg rewrite") {
+    val q = "SELECT avg(number1) WHERE crime_date >= '2011-01-01' AND crime_date < '2019-01-01'"
+    val rewrites = rewritesFor(q)
+    rewrites should have size 0
   }
 }


### PR DESCRIPTION
As a result, developers need to introduce stray group by in rollup and query like

R: 
SELECT count(x), :id is not null GROUP BY date_trunc_ymd(date), :id is not null

Q:
SELECT count:cross_mark: WHERE date >= d1 AND date < d2 GROUP BY :id is not null