### PR TITLE
EN-51750: Support join queries in rollups

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -564,7 +564,12 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLType]) {
         else h
       }
 
-      val joins = rewriteJoin(q.joins, r)
+      val joins = {
+        // might want to tackle updated-ness issue of related table
+        // before we open up join to the public
+        if (!debug && r.joins.nonEmpty) None
+        else rewriteJoin(q.joins, r)
+      }
 
       val mismatch =
         ensure(selection.isDefined, "mismatch on select") orElse

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
@@ -1,0 +1,11 @@
+package com.socrata.querycoordinator
+
+import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.soql.SoQLAnalyzer
+import com.socrata.soql.types.SoQLType
+
+class QueryRewriterWithJoinEnabled(analyzer: SoQLAnalyzer[SoQLType]) extends QueryRewriter(analyzer) {
+  override def possibleRewrites(q: Anal, rollups: Map[RollupName, Anal]): Map[RollupName, Anal] = {
+    possibleRewrites(q, rollups, true)
+  }
+}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -13,7 +13,7 @@ abstract class TestQueryRewriterBase extends TestBase {
   import Join._
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter = new QueryRewriter(analyzer)
+  val rewriter = new QueryRewriterWithJoinEnabled(analyzer)
   val rollups: Seq[(String, String)]
   val rollupAnalysis: Map[RollupName, Anal]
 

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -3,8 +3,9 @@ package com.socrata.querycoordinator
 import com.socrata.querycoordinator.QueryRewriter.{Anal, ColumnId, Expr, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.{SoQLAnalysis, SoQLAnalyzer}
-import com.socrata.soql.environment.{ColumnName, TypeName}
+import com.socrata.soql.environment.{ColumnName, TableName, TypeName}
 import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
+import com.socrata.soql.typed.Qualifier
 import com.socrata.soql.types.SoQLType
 
 abstract class TestQueryRewriterBase extends TestBase {
@@ -42,6 +43,52 @@ abstract class TestQueryRewriterBase extends TestBase {
   /** The dataset context, used for parsing the query */
   val dsContext = QueryParser.dsContext(columnIdMapping, rawSchema)
 
+  val rawSchemaJoin = Map[String, SoQLType](
+    "crim-typ3" -> SoQLType.typesByName(TypeName("text")),
+    "aaaa-aaaa" -> SoQLType.typesByName(TypeName("text")),
+    "bbbb-bbbb" -> SoQLType.typesByName(TypeName("text")),
+    "dddd-dddd" -> SoQLType.typesByName(TypeName("floating_timestamp")),
+    "nnnn-nnnn" -> SoQLType.typesByName(TypeName("number"))
+  )
+
+  val schemaJoin = Schema("NOHASH", rawSchemaJoin, "NOPK")
+
+  val columnIdMappingJoin = Map[ColumnName, ColumnId](
+    ColumnName("crime_type") -> "crim-typ3",
+    ColumnName("aa") -> "aaaa-aaaa",
+    ColumnName("bb") -> "bbbb-bbbb",
+    ColumnName("floating") -> "dddd-dddd",
+    ColumnName("nn") -> "nnnn-nnnn"
+  )
+
+  val dsContextJoin = QueryParser.dsContext(columnIdMappingJoin, rawSchemaJoin)
+
+  val joinTable = TableName("_tttt-tttt", Some("t1"))
+
+  def multiTablesColumnIdMapping(cn: ColumnName, q: Qualifier): ColumnId = {
+    q match {
+      case None =>
+        columnIdMapping(cn)
+      case Some(q) => q == TableName.SodaFountainPrefix + joinTable.qualifier
+        columnIdMappingJoin(cn)
+      case Some(unknown) =>
+        throw new Exception(s"Unknown qualifier $unknown")
+    }
+  }
+
+  def getSchemaWithFieldName(tn: TableName): SchemaWithFieldName = {
+    tn match {
+      case tn: TableName if tn.name == joinTable.name =>
+        val schemaWithFieldName = columnIdMappingJoin.map {
+          case (cn: ColumnName, cid) =>
+            (cid, (rawSchemaJoin(cid), cn.name))
+        }
+        SchemaWithFieldName("NOHASH", schemaWithFieldName, "NOPK")
+      case _ =>
+        throw new Exception("table not found")
+    }
+  }
+
   override def beforeAll() {
     withClue("Not all rollup definitions successfully parsed, check log for failures") {
       rollupAnalysis should have size (rollups.size)
@@ -49,8 +96,11 @@ abstract class TestQueryRewriterBase extends TestBase {
   }
 
   /** Analyze the query and map to column ids, just like we have in real life. */
-  def analyzeQuery(q: String): SoQLAnalysis[ColumnId, SoQLType] =
-    analyzer.analyzeUnchainedQuery(q)(toAnalysisContext(dsContext)).mapColumnIds(mapIgnoringQualifier(columnIdMapping))
+  def analyzeQuery(q: String): SoQLAnalysis[ColumnId, SoQLType] = {
+    val ctx = toAnalysisContext(dsContext) + (joinTable.nameWithSodaFountainPrefix -> dsContextJoin)
+    val analysis = analyzer.analyzeUnchainedQuery(q)(ctx)
+    analysis.mapColumnIds(multiTablesColumnIdMapping)
+  }
 
   /** Silly half-assed function for debugging when things don't match */
   def compareProducts(a: Product, b: Product, indent: Int = 0): Unit = {

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -27,7 +27,7 @@ class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
   /** Pull in the rollupAnalysis for easier debugging */
-  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, getSchemaWithFieldName)
 
   val rollupRawSchemas = rollupAnalysis.mapValues { case analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
@@ -21,7 +21,7 @@ class TestQueryRewriterWindowFunction extends TestQueryRewriterBase {
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
   /** Pull in the rollupAnalysis for easier debugging */
-  val rollupAnalysis: Map[RollupName, Anal] = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
+  val rollupAnalysis: Map[RollupName, Anal] = rewriter.analyzeRollups(schema, rollupInfos, getSchemaWithFieldName)
 
   val rollupRawSchemas = rollupAnalysis.mapValues { analysis: Anal =>
     analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
@@ -26,7 +26,7 @@ class TestRollupScorer extends TestQueryRewriterBase {
   val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2) }
 
   /** Pull in the rollupAnalysis for easier debugging */
-  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, Map.empty)
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos, getSchemaWithFieldName)
 
   test("rollup scoring") {
     // validate we don't have any ties, which could confuse things due to having no clear ordering.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.0.30-SNAPSHOT"
+ThisBuild / version := "3.1.0-SNAPSHOT"


### PR DESCRIPTION
This is a general effort in improving query performance by supporting a wider variety of queries in rollups.
Join queries can use rollups when their joins match.
Rollup updated-ness is out of scope.  We only update rollups when the primary table is changed.  Join table change will not trigger rollup refresh.  Because of this, we limit this usage to superadmin via special request header.