### PR TITLE
EN-55111: Keep track of non-primary rollup application (at joins)

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -828,4 +828,8 @@ object QueryRewriter {
       case _ => false
     }.mapValues(_.outputSchema.leaf)
   }
+
+  def primaryRollup(names: Seq[String]): Option[String] = {
+    names.filterNot(_.startsWith(TableName.SoqlPrefix)).headOption
+  }
 }


### PR DESCRIPTION
This allow us to retry the query without rollup in case there is anything wrong with the query rewritten with rollup.  This behavior is now identical to how we handle primary rollup application.