### PR TITLE
EN-54831 - give params in context for analysis

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "4.8.3"
+    val soqlStdlib = "4.8.5"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryCoordinatorErrors.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryCoordinatorErrors.scala
@@ -45,6 +45,7 @@ object QueryCoordinatorErrors {
     val unknownColumnIds = "req.unknown.column-ids"
     val rowLimitExceeded = "req.row-limit-exceeded"
     val invalidJoin = "req.invalid-join"
+    val missingLensUid = "req.missing-lens-uid"
   }
 
 }

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -2,7 +2,7 @@ package com.socrata.querycoordinator
 
 import com.socrata.http.client.RequestBuilder
 import com.socrata.querycoordinator.SchemaFetcher.{NoSuchDatasetInSecondary, Successful}
-import com.socrata.querycoordinator.exceptions.JoinedDatasetNotColocatedException
+import com.socrata.querycoordinator.exceptions.{JoinedDatasetNotColocatedException, ParameterSpecException}
 import com.socrata.querycoordinator.fusion.{CompoundTypeFuser, SoQLRewrite}
 import com.socrata.querycoordinator.util.BinaryTreeHelper
 import com.socrata.soql.ast.{JoinFunc, JoinQuery, JoinTable, Select}
@@ -12,10 +12,11 @@ import com.socrata.soql.exceptions.SoQLException
 import com.socrata.soql.functions.SoQLFunctions
 import com.socrata.soql.parsing.{AbstractParser, Parser}
 import com.socrata.soql.typed._
-import com.socrata.soql.types.{SoQLType, SoQLValue}
-import com.socrata.soql.{AnalysisContext, BinaryTree, Compound, Leaf, ParameterSpec, PipeQuery, SoQLAnalysis, SoQLAnalyzer, ast}
+import com.socrata.soql.types.{SoQLNumber, SoQLType, SoQLValue}
+import com.socrata.soql.{AnalysisContext, BinaryTree, Compound, Leaf, ParameterSpec, ParameterValue, PipeQuery, PresentParameter, SoQLAnalysis, SoQLAnalyzer, ast}
 import com.typesafe.scalalogging.Logger
 import org.joda.time.DateTime
+import com.socrata.soql.stdlib.Context
 
 
 class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: SchemaFetcher, maxRows: Option[Int], defaultRowsLimit: Int) {
@@ -24,11 +25,25 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
 
   type AnalysisContext = com.socrata.soql.AnalysisContext[SoQLType, SoQLValue]
 
-  private def go(columnIdMapping: Map[ColumnName, String], schema: Map[String, SoQLType])
+  private def go(columnIdMapping: Map[ColumnName, String], schema: Map[String, SoQLType], context: Context, lensUid: Option[String])
                 (f: AnalysisContext => (BinaryTree[SoQLAnalysis[ColumnName, SoQLType]], Map[QualifiedColumnName, String], DateTime)): Result = {
+      val parameters = (context.user.num.toSeq ++
+        context.user.text.toSeq ++
+        context.user.bool.toSeq ++
+        context.user.fixed.toSeq ++
+        context.user.floating.toSeq)
+        .filter { case(name,_) => name.contains(".")}
 
-    val ds = toAnalysisContext(dsContext(columnIdMapping, schema))
     try {
+      val uid = lensUid match {
+        case Some(uid) => uid
+        case None => throw new ParameterSpecException("lensUid missing from request. It is needed to build the ParamterSpec")
+      }
+
+      val paramSpec = ParameterSpec(namespaceParams(parameters), uid)
+
+      val ds = toAnalysisContext(dsContext(columnIdMapping, schema), paramSpec)
+
       val (analyses, joinColumnIdMapping, dateTime) = f(ds)
       limitRows(analyses) match {
         case Right(analyses) =>
@@ -37,11 +52,21 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
         case Left(result) => result
       }
     } catch {
+      case e: ParameterSpecException =>
+        ParameterSpecError(e.message)
       case e: SoQLException =>
         AnalysisError(e)
       case e: JoinedDatasetNotColocatedException =>
         QueryParser.JoinedTableNotFound(e.dataset, e.secondaryHost)
     }
+  }
+  private def namespaceParams(contextParams: Seq[(String, SoQLValue)]): Map[String, Map[HoleName, ParameterValue[SoQLType, SoQLValue]]] = {
+    contextParams.map { case(k,v) => {
+      val (name, namespace) = k.splitAt(k.lastIndexOf("."))
+      (namespace.drop(1), name, v)
+    }}
+      .groupBy(_._1)
+      .mapValues(v => v.map { case (_,b,c) => (HoleName(b),PresentParameter(c)) }.toMap)
   }
 
   private def limitRows(analyses: BinaryTree[SoQLAnalysis[ColumnName, SoQLType]])
@@ -176,11 +201,13 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
             schema: Map[String, SoQLType],
             selectedSecondaryInstanceBase: RequestBuilder,
             fuseMap: Map[String, String] = Map.empty,
+            context: Context,
+            lensUid: Option[String],
             merged: Boolean = true): Result = {
     val compoundTypeFuser = CompoundTypeFuser(fuseMap)
     val postAnalyze = analyzeQuery(query, columnIdMapping, selectedSecondaryInstanceBase, compoundTypeFuser, schema)
     val analyzeMaybeMerge = if (merged) { postAnalyze andThen soqlMerge } else { postAnalyze }
-    go(columnIdMapping, schema)(analyzeMaybeMerge)
+    go(columnIdMapping, schema, context, lensUid)(analyzeMaybeMerge)
   }
 
   private def soqlMerge(analysesAndColumnIdMap: (BinaryTree[SoQLAnalysis[ColumnName, SoQLType]], Map[QualifiedColumnName, String], DateTime))
@@ -204,6 +231,8 @@ object QueryParser {
   case class RowLimitExceeded(max: BigInt) extends Result
 
   case class JoinedTableNotFound(joinedTable: String, secondaryHost: String) extends Result
+
+  case class ParameterSpecError(message: String) extends Result
 
   /**
    * Make schema which is a mapping of column name to datatype

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -35,12 +35,16 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
         .filter { case(name,_) => name.contains(".")}
 
     try {
-      val uid = lensUid match {
-        case Some(uid) => uid
-        case None => throw new ParameterSpecException("lensUid missing from request. It is needed to build the ParamterSpec")
-      }
+      val paramSpec = if (parameters.isEmpty) {
+        ParameterSpec.empty
+      } else {
+        val uid = lensUid match {
+          case Some(uid) => uid
+          case None => throw new ParameterSpecException("lensUid missing from request. It is needed to build the ParamterSpec")
+        }
 
-      val paramSpec = ParameterSpec(namespaceParams(parameters), uid)
+        ParameterSpec(namespaceParams(parameters), uid)
+      }
 
       val ds = toAnalysisContext(dsContext(columnIdMapping, schema), paramSpec)
 
@@ -200,9 +204,9 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
             columnIdMapping: Map[ColumnName, String],
             schema: Map[String, SoQLType],
             selectedSecondaryInstanceBase: RequestBuilder,
+            context: Context = Context.empty,
+            lensUid: Option[String] = None,
             fuseMap: Map[String, String] = Map.empty,
-            context: Context,
-            lensUid: Option[String],
             merged: Boolean = true): Result = {
     val compoundTypeFuser = CompoundTypeFuser(fuseMap)
     val postAnalyze = analyzeQuery(query, columnIdMapping, selectedSecondaryInstanceBase, compoundTypeFuser, schema)

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/exceptions/ParameterSpecException.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/exceptions/ParameterSpecException.scala
@@ -1,0 +1,3 @@
+package com.socrata.querycoordinator.exceptions
+
+class ParameterSpecException(val message: String) extends Exception(message)

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -146,7 +146,7 @@ class QueryResource(secondary: Secondary,
             })
 
           val columnIdMap = extractColumnIdMap(schemaWithFieldNames.payload)
-          val parsedQuery = queryParser(query, columnIdMap, schema.schema, base, fuseMap, context, lensUid)
+          val parsedQuery = queryParser(query, columnIdMap, schema.schema, base, context, lensUid, fuseMap)
 
           parsedQuery match {
             case QueryParser.SuccessfulParse(analysis, largestLastModifiedOfJoins) =>

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -89,6 +89,7 @@ class QueryResource(secondary: Secondary,
         JsonUtil.parseJson[Context](cStr).right.get
       }
 
+      val lensUid = Option(servReq.getParameter("lensUid"))
       val rowCount = Option(servReq.getParameter("rowCount"))
       val copy = Option(servReq.getParameter("copy"))
       val queryTimeoutSeconds = Option(servReq.getParameter(qpQueryTimeoutSeconds))
@@ -145,7 +146,7 @@ class QueryResource(secondary: Secondary,
             })
 
           val columnIdMap = extractColumnIdMap(schemaWithFieldNames.payload)
-          val parsedQuery = queryParser(query, columnIdMap, schema.schema, base, fuseMap)
+          val parsedQuery = queryParser(query, columnIdMap, schema.schema, base, fuseMap, context, lensUid)
 
           parsedQuery match {
             case QueryParser.SuccessfulParse(analysis, largestLastModifiedOfJoins) =>
@@ -172,6 +173,8 @@ class QueryResource(secondary: Secondary,
               } else {
                 Left(nextRetry)
               }
+            case QueryParser.ParameterSpecError(message) =>
+              finishRequest(missingLensUid(message))
           }
         }
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryService.scala
@@ -178,6 +178,10 @@ trait QueryService {
                              Map(qpLimit -> JNumber(max)))
   }
 
+  def missingLensUid(message: String): HttpResponse = {
+    BadRequest ~> errContent(RequestErrors.missingLensUid, message, Map())
+  }
+
   def joinedTableNotFound(dataset: String, resource: String, secondaries: Set[String]): HttpResponse = {
     NotFound ~> errContent(QueryErrors.isNotCollocated, s"joined dataset $dataset is not collocated in secondaries",
       Map("resource" -> JString(resource),

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/Join.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/Join.scala
@@ -10,10 +10,10 @@ object Join {
   val NoQualifier: Qualifier = None
 
   // TODO: Join - from one to multiple contexts
-  def toAnalysisContext(ctx: DatasetContext[SoQLType]): AnalysisContext[SoQLType, SoQLValue] = {
+  def toAnalysisContext(ctx: DatasetContext[SoQLType], parameters: ParameterSpec[SoQLType, SoQLValue] = ParameterSpec.empty): AnalysisContext[SoQLType, SoQLValue] = {
     AnalysisContext(
       schemas = Map(TableName.PrimaryTable.qualifier -> ctx),
-      parameters = ParameterSpec.empty
+      parameters = parameters
     )
   }
 

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/QueryParserFuseTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/QueryParserFuseTest.scala
@@ -10,6 +10,7 @@ import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.functions._
 import com.socrata.soql.typed._
 import com.socrata.soql.types._
+import com.socrata.soql.stdlib.Context
 
 class QueryParserFuseTest extends TestBase {
   import QueryParserFuseTest._ // scalastyle:ignore import.grouping
@@ -27,7 +28,8 @@ class QueryParserFuseTest extends TestBase {
       ColumnName("phone") -> phoneFc
     )
 
-    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuse) match {
+
+    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuseMap = fuse) match {
       case SuccessfulParse(analyses, _) =>
         val actual = SoQLAnalysisDepositioner(analyses.asLeaf.get)
         actual.selection should be(expectedSelection)
@@ -44,7 +46,7 @@ class QueryParserFuseTest extends TestBase {
       ColumnName("phone") -> phoneFc
     )
 
-    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuse) match {
+    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuseMap = fuse) match {
       case SuccessfulParse(analyses, _) =>
         val actual = SoQLAnalysisDepositioner(analyses.seq.head)
         actual.selection should be(expectedSelection)
@@ -62,7 +64,7 @@ class QueryParserFuseTest extends TestBase {
       ColumnName("a") -> ColumnRef(NoQualifier, "ai", SoQLText)(NoPosition)
     )
 
-    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuse) match {
+    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuseMap = fuse) match {
       case SuccessfulParse(analyses, _) =>
         val actual = SoQLAnalysisDepositioner(analyses.seq.head)
         actual.selection should be(expectedSelection)
@@ -82,7 +84,7 @@ class QueryParserFuseTest extends TestBase {
       ColumnName(":id") -> ColumnRef(NoQualifier, ":id", SoQLID)(NoPosition)
     )
 
-    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, Map.empty) match {
+    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuseMap = Map.empty) match {
       case SuccessfulParse(analyses, _) =>
         val actual = SoQLAnalysisDepositioner(analyses.seq.head)
         actual.selection should be(expectedSelection)
@@ -99,7 +101,7 @@ class QueryParserFuseTest extends TestBase {
       ColumnName("a") -> ColumnRef(NoQualifier, "ai", SoQLText)(NoPosition)
     )
 
-    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, Map.empty) match {
+    val actual = qp.apply(query, truthColumns, schema, fakeRequestBuilder, fuseMap = Map.empty) match {
       case SuccessfulParse(analyses, _) =>
         val actual = SoQLAnalysisDepositioner(analyses.seq.head)
       case x: QueryParser.Result =>


### PR DESCRIPTION
Now that we do not replace query params upstream, we need to give the analyzer context. This pr builds up the context for the analyzer, using the lens id passed from soda fountain in this pr: https://github.com/socrata-platform/soda-fountain/pull/383/files