### PR TITLE
NOJIRA: Separating QueryRewriter interface and implementation

### DIFF
--- a/.run/query-coordinator.run.xml
+++ b/.run/query-coordinator.run.xml
@@ -7,7 +7,7 @@
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <extension name="coverage">
       <pattern>
-        <option name="PATTERN" value="com.socrata.querycoordinator.*" />
+        <option name="PATTERN" value="com.socrata.querycoordinator.rollups.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>

--- a/.run/query-coordinator.run.xml
+++ b/.run/query-coordinator.run.xml
@@ -7,7 +7,7 @@
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <extension name="coverage">
       <pattern>
-        <option name="PATTERN" value="com.socrata.querycoordinator.rollups.*" />
+        <option name="PATTERN" value="com.socrata.querycoordinator.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
@@ -2,7 +2,6 @@ package com.socrata.querycoordinator
 
 import java.io.InputStream
 import java.util.concurrent.Executors
-
 import com.socrata.querycoordinator.caching.cache.CacheCleanerThread
 import com.socrata.querycoordinator.caching.cache.config.CacheSessionProviderFromConfig
 import com.rojoma.json.v3.ast.JString
@@ -13,7 +12,7 @@ import com.socrata.http.server.SocrataServerJetty
 import com.socrata.http.server.curator.CuratorBroker
 import com.socrata.http.server.livenesscheck.LivenessCheckResponder
 import com.socrata.http.server.util.RequestId.ReqIdHeader
-import com.socrata.http.server.util.handlers.{LoggingOptions, ErrorCatcher, NewLoggingHandler, ThreadRenamingHandler}
+import com.socrata.http.server.util.handlers.{ErrorCatcher, LoggingOptions, NewLoggingHandler, ThreadRenamingHandler}
 import com.socrata.querycoordinator.caching.Windower
 import com.socrata.querycoordinator.resources.{QueryResource, VersionResource}
 import com.socrata.querycoordinator.util.TeeToTempInputStream
@@ -21,6 +20,7 @@ import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
 import com.socrata.soql.types.SoQLType
 import com.socrata.soql.{AnalysisSerializer, SoQLAnalyzer}
 import com.socrata.curator.{ConfigWatch, CuratorFromConfig, DiscoveryFromConfig}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation, RollupInfoFetcher}
 import com.socrata.thirdparty.metrics.{MetricsReporter, SocrataHttpSupport}
 import com.socrata.thirdparty.typesafeconfig.Propertizer
 import com.typesafe.config.{Config, ConfigFactory}
@@ -107,7 +107,7 @@ object Main extends App {
       schemaCache = (_, _, _) => (),
       schemaDecache = (_, _) => None,
       secondaryInstance = secondaryInstanceSelector,
-      queryRewriter = new QueryRewriter(analyzer),
+      queryRewriter = new QueryRewriterImplementation(analyzer),
       rollupInfoFetcher = new RollupInfoFetcher(httpClient)
     )
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -3,10 +3,9 @@ package com.socrata.querycoordinator.rollups
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, Expr, RollupName}
 import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
 import com.socrata.soql.environment.{ColumnName, TableName}
-import com.socrata.soql.functions.{Function, SoQLFunctions}
+import com.socrata.soql.functions.{SoQLFunctions}
 import com.socrata.soql.{BinaryTree, SoQLAnalysis}
-import com.socrata.soql.types.{SoQLFloatingTimestamp, SoQLType}
-import org.slf4j.Logger
+import com.socrata.soql.types.{SoQLType}
 
 /**
   *
@@ -38,7 +37,7 @@ abstract class QueryRewriter {
     *
     */
   def bestRollup(rollups: Seq[(RollupName, Anal)]): Option[(RollupName, Anal)]
-  
+
 }
 
 object QueryRewriter {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -2,12 +2,10 @@ package com.socrata.querycoordinator.rollups
 
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, Expr, RollupName}
 import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
-import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.{ColumnName, TableName}
-import com.socrata.soql.functions.{Function, MonomorphicFunction, SoQLFunctions}
-import com.socrata.soql.functions.SoQLFunctions.{And, Coalesce, Count, DivNumNum, Sum}
-import com.socrata.soql.{BinaryTree, Compound, Leaf, SoQLAnalysis, typed}
-import com.socrata.soql.types.{SoQLBoolean, SoQLFloatingTimestamp, SoQLNumber, SoQLType}
+import com.socrata.soql.functions.{Function, SoQLFunctions}
+import com.socrata.soql.{BinaryTree, SoQLAnalysis}
+import com.socrata.soql.types.{SoQLFloatingTimestamp, SoQLType}
 import org.slf4j.Logger
 
 /**
@@ -40,19 +38,7 @@ abstract class QueryRewriter {
     *
     */
   def bestRollup(rollups: Seq[(RollupName, Anal)]): Option[(RollupName, Anal)]
-
-  /**
-    * Auxiliary functions used in tests
-    *
-    * ToDo: should this be private / package private ?
-    *
-    */
-  val log: Logger
-  def rollupColumnId(idx: Int): String
-  def rewriteExpr(e: Expr, r: Anal, rollupColIdx: Map[Expr, Int]): Option[Expr]
-
-  def truncatedTo(soqlTs: SoQLFloatingTimestamp): Option[Function[SoQLType]]
-
+  
 }
 
 object QueryRewriter {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -1,0 +1,90 @@
+package com.socrata.querycoordinator.rollups
+
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, Expr, RollupName}
+import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
+import com.socrata.soql.collection.OrderedMap
+import com.socrata.soql.environment.{ColumnName, TableName}
+import com.socrata.soql.functions.{Function, MonomorphicFunction, SoQLFunctions}
+import com.socrata.soql.functions.SoQLFunctions.{And, Coalesce, Count, DivNumNum, Sum}
+import com.socrata.soql.{BinaryTree, Compound, Leaf, SoQLAnalysis, typed}
+import com.socrata.soql.types.{SoQLBoolean, SoQLFloatingTimestamp, SoQLNumber, SoQLType}
+import org.slf4j.Logger
+
+/**
+  *
+  * This is the interface of the QueryRewriter
+  *
+  * Any class wishing to use the QueryRewriter must use the interface, not a concrete implementation.
+  */
+abstract class QueryRewriter {
+
+  /**
+    * *Map rollup definitions into query analysis in schema context
+    *
+    * ToDo: Should this return merged analysis?
+    *
+    */
+  def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
+                     getSchemaByTableName: TableName => SchemaWithFieldName): Map[RollupName, BinaryTree[Anal]]
+
+  /**
+    * Creates possible rewrites for the query given the rollups
+    *
+    */
+  def possibleRewrites(q: Anal, rollups: Map[RollupName, Anal]): Map[RollupName, Anal]
+  def possibleRewrites(q: BinaryTree[Anal], rollups: Map[RollupName, BinaryTree[Anal]], requireCompoundRollupHint: Boolean): (BinaryTree[Anal], Seq[String])
+  def possibleRewrites(q: Anal, rollups: Map[RollupName, Anal], debug: Boolean): Map[RollupName, Anal]
+
+  /**
+    * Returns best scored rollup
+    *
+    */
+  def bestRollup(rollups: Seq[(RollupName, Anal)]): Option[(RollupName, Anal)]
+
+  /**
+    * Auxiliary functions used in tests
+    *
+    * ToDo: should this be private / package private ?
+    *
+    */
+  val log: Logger
+  def rollupColumnId(idx: Int): String
+  def rewriteExpr(e: Expr, r: Anal, rollupColIdx: Map[Expr, Int]): Option[Expr]
+
+  def truncatedTo(soqlTs: SoQLFloatingTimestamp): Option[Function[SoQLType]]
+
+}
+
+object QueryRewriter {
+  import com.socrata.soql.typed._ // scalastyle:ignore import.grouping
+
+  type Anal = SoQLAnalysis[ColumnId, SoQLType]
+  type ColumnId = String
+  type RollupName = String
+  type Expr = CoreExpr[ColumnId, SoQLType]
+
+  def rollupAtJoin(q: Anal): Boolean = {
+    q.hints.exists {
+      case RollupAtJoin(_) => true
+      case _ => false
+    }
+  }
+
+  /**
+    * Merge rollups analysis
+    */
+  def mergeRollupsAnalysis(rus: Map[RollupName, BinaryTree[Anal]]): Map[RollupName, Anal] = {
+    rus.mapValues(bt =>
+      SoQLAnalysis.merge(
+        SoQLFunctions.And.monomorphic.get,
+        bt.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId))
+        )
+      ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
+    )
+  }
+
+  def primaryRollup(names: Seq[String]): Option[String] = {
+    names.filterNot(_.startsWith(TableName.SoqlPrefix)).headOption
+  }
+}
+

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriterImplementation.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriterImplementation.scala
@@ -28,7 +28,7 @@ class QueryRewriterImplementation(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) e
 
   // TODO the secondary should probably just give us the names of the columns when we ask about the rollups
   // instead of assuming.
-  def rollupColumnId(idx: Int): String = "c" + (idx + 1)
+  private[querycoordinator] def rollupColumnId(idx: Int): String = "c" + (idx + 1)
 
   /** Maps the rollup column expression to the 0 based index in the rollup table.  If we have
     * multiple columns with the same definition, that is fine but we will only use one.

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupInfo.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupInfo.scala
@@ -1,4 +1,4 @@
-package com.socrata.querycoordinator
+package com.socrata.querycoordinator.rollups
 
 import com.rojoma.json.v3.util.AutomaticJsonCodecBuilder
 import com.socrata.querycoordinator.util.SoQLTypeCodec

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupInfoFetcher.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupInfoFetcher.scala
@@ -1,13 +1,13 @@
-package com.socrata.querycoordinator
-
-import java.io.IOException
-import javax.servlet.http.HttpServletResponse
+package com.socrata.querycoordinator.rollups
 
 import com.rojoma.json.io.JsonReaderException
 import com.rojoma.json.util.JsonArrayIterator.ElementDecodeException
 import com.socrata.http.client.exceptions.{HttpClientException, HttpClientTimeoutException, LivenessCheckFailed}
 import com.socrata.http.client.{HttpClient, RequestBuilder, Response}
-import com.socrata.querycoordinator.RollupInfoFetcher._
+import com.socrata.querycoordinator.rollups.RollupInfoFetcher._
+
+import java.io.IOException
+import javax.servlet.http.HttpServletResponse
 
 /**
  * Fetches the rollup info from the secondary server.  Modelled after the SchemaFetcher, it would be nice

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
@@ -26,6 +26,8 @@ import com.typesafe.scalalogging.Logger
  *
  */
 import com.socrata.querycoordinator.rollups.QueryRewriter._
+import com.socrata.querycoordinator.rollups.QueryRewriterImplementation._
+
 
 private final abstract class RollupScorer
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
@@ -1,4 +1,4 @@
-package com.socrata.querycoordinator
+package com.socrata.querycoordinator.rollups
 
 import com.socrata.soql.functions.SoQLFunctions
 import com.typesafe.scalalogging.Logger
@@ -25,11 +25,11 @@ import com.typesafe.scalalogging.Logger
  * - For each value in the selection, give a minor penalty of 1
  *
  */
-import QueryRewriter._
+import com.socrata.querycoordinator.rollups.QueryRewriter._
 
 private final abstract class RollupScorer
 
-private object RollupScorer {
+object RollupScorer {
   private val logger = Logger[RollupScorer]
 
   private val SELECTION_SCORE_PENALTY = -10L

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterTest.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
 import com.socrata.querycoordinator.QueryRewritingTestUtility._
+import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
 import com.socrata.soql.SoQLAnalyzer
 import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
 import com.socrata.soql.parsing.{AbstractParser, Parser}
@@ -18,7 +19,7 @@ class QueryRewriterTest extends FunSuite {
     val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
     val parserParams = AbstractParser.Parameters(allowJoins = true)
     val parser = new Parser(parserParams)
-    val rewriter = new QueryRewriter(analyzer)
+    val rewriter: QueryRewriter = new QueryRewriterImplementation(analyzer)
 
 
     // Given dataset definitions (multiple datasets)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
@@ -1,10 +1,11 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.querycoordinator.rollups.{QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, RollupName}
 import com.socrata.soql.SoQLAnalyzer
 import com.socrata.soql.types.{SoQLType, SoQLValue}
 
-class QueryRewriterWithJoinEnabled(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) extends QueryRewriter(analyzer) {
+class QueryRewriterWithJoinEnabled(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) extends QueryRewriterImplementation(analyzer) {
   override def possibleRewrites(q: Anal, rollups: Map[RollupName, Anal]): Map[RollupName, Anal] = {
     possibleRewrites(q, rollups, true)
   }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewritingTestUtility.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewritingTestUtility.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{ColumnId, RollupName}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.QueryRewriter.{ColumnId, RollupName}
 import com.socrata.soql._
 import com.socrata.soql.ast.Select
 import com.socrata.soql.collection.OrderedMap
@@ -37,7 +38,7 @@ object QueryRewritingTestUtility {
     val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
     val parserParams = AbstractParser.Parameters(allowJoins = true)
     val parser = new Parser(parserParams)
-    val rewriter = new QueryRewriter(analyzer)
+    val rewriter: QueryRewriter = new QueryRewriterImplementation(analyzer)
     AssertRewrite(
       parser.binaryTreeSelect,
       // aka Analyze(analyzer)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestCompoundQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestCompoundQueryRewriterBase.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, ColumnId, RollupName}
+import com.socrata.querycoordinator.rollups.{QueryRewriter}
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, ColumnId, RollupName}
 import com.socrata.soql.{AnalysisContext, BinaryTree, Compound, Leaf, ParameterSpec, SoQLAnalysis, SoQLAnalyzer}
 import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.{ColumnName, DatasetContext}
@@ -12,7 +13,7 @@ import com.socrata.soql.types.{SoQLFloatingTimestamp, SoQLNumber, SoQLText, SoQL
 trait TestCompoundQueryRewriterBase { this: TestBase =>
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter = new QueryRewriterWithJoinEnabled(analyzer)
+  val rewriter: QueryRewriter = new QueryRewriterWithJoinEnabled(analyzer)
   val rollupAnalysis: Map[RollupName, Anal]
   val rollupAnalyses: Map[RollupName, BinaryTree[Anal]] = Map.empty
   val rollups: Iterable[_]

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestCompoundQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestCompoundQueryRewriterBase.scala
@@ -13,7 +13,7 @@ import com.socrata.soql.types.{SoQLFloatingTimestamp, SoQLNumber, SoQLText, SoQL
 trait TestCompoundQueryRewriterBase { this: TestBase =>
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter: QueryRewriter = new QueryRewriterWithJoinEnabled(analyzer)
+  val rewriter = new QueryRewriterWithJoinEnabled(analyzer)
   val rollupAnalysis: Map[RollupName, Anal]
   val rollupAnalyses: Map[RollupName, BinaryTree[Anal]] = Map.empty
   val rollups: Iterable[_]

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriter.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.querycoordinator.rollups.QueryRewriter
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.SoQLAnalysis
 import com.socrata.soql.environment.ColumnName

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, ColumnId, Expr, RollupName}
+import com.socrata.querycoordinator.rollups.QueryRewriter
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, ColumnId, Expr, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.SoQLAnalysis
 import com.socrata.soql.environment.{ColumnName, TableName, TypeName}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -1,6 +1,6 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.rollups.QueryRewriter
+import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, ColumnId, Expr, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.SoQLAnalysis
@@ -116,7 +116,7 @@ abstract class TestQueryRewriterBase extends TestBase with TestCompoundQueryRewr
   /**
     * A handy function to test QueryRewriter.rewriteExpr
     */
-  def rewriteExpr(rewriter: QueryRewriter, e: Expr, q: Anal, rollups: Map[RollupName, Anal]): Map[RollupName, Option[Expr]] = {
+  def rewriteExpr(rewriter: QueryRewriterImplementation, e: Expr, q: Anal, rollups: Map[RollupName, Anal]): Map[RollupName, Option[Expr]] = {
     rollups.mapValues { case r =>
       val rollupColIdx = r.selection.values.zipWithIndex.toMap
       rewriter.rewriteExpr(e, r, rollupColIdx)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, RollupInfo}
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.SoQLAnalysis
 import com.socrata.soql.environment.ColumnName

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterWindowFunction.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.QueryRewriter.{Anal, RollupName}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, RollupInfo}
+import com.socrata.querycoordinator.rollups.QueryRewriter.{Anal, RollupName}
 import com.socrata.querycoordinator.util.Join.toAnalysisContext
 import com.socrata.querycoordinator.util.Join.mapIgnoringQualifier
 import com.socrata.soql.SoQLAnalysis

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestRollupScorer.scala
@@ -1,5 +1,7 @@
 package com.socrata.querycoordinator
 
+import com.socrata.querycoordinator.rollups.{QueryRewriter, RollupInfo, RollupScorer}
+
 class TestRollupScorer extends TestQueryRewriterBase {
   /** Each rollup here is defined by:
     * - a name

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuserTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuserTest.scala
@@ -1,8 +1,9 @@
 package com.socrata.querycoordinator.fusion
 
-import com.socrata.querycoordinator.QueryRewriter._
+import com.socrata.querycoordinator.rollups.QueryRewriter._
 import com.socrata.querycoordinator.caching.SoQLAnalysisDepositioner
-import com.socrata.querycoordinator.{QueryParser, QueryRewriter, Schema, TestBase}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
+import com.socrata.querycoordinator.{QueryParser, Schema, TestBase}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.ast.Select
 import com.socrata.soql.{BinaryTree, SoQLAnalyzer}
@@ -20,7 +21,7 @@ class CompoundTypeFuserTest extends TestBase {
   import Join._
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter = new QueryRewriter(analyzer)
+  val rewriter: QueryRewriter = new QueryRewriterImplementation(analyzer)
 
   /** The raw of the table that we get as part of the secondary /schema call */
   val rawSchema = Map[String, SoQLType](

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
@@ -1,7 +1,7 @@
 package com.socrata.querycoordinator.rollups
 
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonUtil}
-import com.socrata.querycoordinator.QueryRewriter.{ColumnId, RollupName}
+import QueryRewriter.{ColumnId, RollupName}
 import com.socrata.querycoordinator._
 import com.socrata.soql._
 import com.socrata.soql.collection.OrderedMap
@@ -31,7 +31,7 @@ class TestRollupQueryRewriter extends TestBase {
   // System Under Test
   //
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter = new QueryRewriterWithJoinEnabled(analyzer)
+  val rewriter: QueryRewriter = new QueryRewriterWithJoinEnabled(analyzer)
 
   //
   //  Helper methods


### PR DESCRIPTION
QueryRewriter is a large class and it is a dependency used by QueryResource. QueryResource only uses (and so needs to now) a few methods from QueryRewriter - i.e. an interface. It is better to separate an interface from the implementation - less coupling, clear interface definition, easier to understand code.

With readability and code organization in mind, classes related to large functional block (i.e. rollups) are better placed in a package.

The changes made in this PR:
- QueryRewriter becomes an abstract class defining the interface
- QueryRewriterImplementation implements it
- files related to the rollups moved to query coordinator.rollups 
- some utility methods moved from companion to class