### PR TITLE
Retry instead of failing when not found in the chosen secondary

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -236,7 +236,7 @@ class QueryResource(secondary: Secondary,
               Left(nextRetry)
             case QueryExecutor.NotFound =>
               chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
-              finishRequest(notFoundResponse(dataset))
+              Left(nextRetry)
             case QueryExecutor.Timeout =>
               // don't flag an error in this case because the timeout may be based on the particular query.
               finishRequest(upstreamTimeoutResponse)


### PR DESCRIPTION
This can happen if the dataset is moved out from under us (e.g., because of a collocation).  This can turn a "not found" reponse into either a "ran out of retries" or a "dataset not available" if the dataset is genuinely gone - but if the dataset had been gone and not in our cache in the first place, it would've been "dataset not available" anyway.