### PR TITLE
[EN-58131] filter function is incorrectly applied

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
@@ -111,6 +111,7 @@ class ExpressionRewriter(val rollupColumnId: (Int) => String,
   private def findCountStarOrLiteral(fc: FunctionCall, rollupColIdx: Map[Expr, Int]): Option[Int] = {
     rollupColIdx.find {
       case (e: FunctionCall, _) if e.filter == fc.filter => isCountStarOrLiteral(e)
+      case (e: FunctionCall, _) if e.filter == None => isCountStarOrLiteral(e)
       case _ => false
     }.map(_._2)
   }

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
@@ -97,7 +97,7 @@ class ExpressionRewriter(val rollupColumnId: (Int) => String,
   private def rewriteCountStarOrLiteral(r: Analysis, rollupColIdx: Map[Expr, Int], fc: FunctionCall): Option[Expr] = {
     val filterAndRollupWhere = andRollupWhereToFilter(fc.filter, r: Analysis)
     for {
-      idx <- findCountStarOrLiteral(rollupColIdx) // find count(*) column in rollup
+      idx <- findCountStarOrLiteral(fc, rollupColIdx) // find count(*) column in rollup with matching filter
       rwFilter <- rewriteWhere(filterAndRollupWhere, r, rollupColIdx)
     } yield {
       val simplifiedRwFilter = simplifyAndTrue(rwFilter)
@@ -108,9 +108,9 @@ class ExpressionRewriter(val rollupColumnId: (Int) => String,
   }
 
   /** Find the first column index that is a count(*) or count(literal). */
-  private def findCountStarOrLiteral(rollupColIdx: Map[Expr, Int]): Option[Int] = {
+  private def findCountStarOrLiteral(fc: FunctionCall, rollupColIdx: Map[Expr, Int]): Option[Int] = {
     rollupColIdx.find {
-      case (fc: FunctionCall, _) => isCountStarOrLiteral(fc)
+      case (e: FunctionCall, _) if e.filter == fc.filter => isCountStarOrLiteral(e)
       case _ => false
     }.map(_._2)
   }

--- a/query-coordinator/src/test/resources/rollups/query_rewriter_test_configs/test_filtering.json
+++ b/query-coordinator/src/test/resources/rollups/query_rewriter_test_configs/test_filtering.json
@@ -1,0 +1,41 @@
+{
+  "schemas": {
+    "_": {
+      "a193-1190": ["number", "ftrans_id"],
+      "a173-1170": ["number", "order_id"],
+      "a183-1180": ["floating_timestamp", "TIMESTAMP"],
+      "a165-1162": ["floating_timestamp", "settle_date"],
+      "a167-1164": ["text", "implement_type"],
+      "a171-1168": ["text", "implement_name"],
+      "a184-1181": ["text", "transaction_type"],
+      "a170-1167": ["text", "account_number"],
+      "a166-1163": ["text", "merchant"],
+      "a178-1175": ["text", "service"],
+      "a179-1176": ["number", "transaction_amount"],
+      "a174-1171": ["text", "failure_message"],
+      "a187-1184": ["text", "processor"],
+      "a194-1191": ["text", "order_url"],
+      "a180-1177": ["number", "processing_cost"],
+      "a190-1187": ["text", "customer_state"],
+      "a161-1158": ["text", "billing_state"],
+      "a181-1178": ["text", "customer_country"],
+      "a164-1161": ["text", "billing_country"],
+      "a188-1185": ["text", "government_level"],
+      "a186-1183": ["text", "agency_category"],
+      "a175-1172": ["text", "email_address"]
+    }
+  },
+  "rollups": {
+    "r1": "SELECT date_trunc_ymd(`timestamp`) AS `date_trunc_ymd_timestamp`, `merchant`, `implement_type`, `service`, `implement_name`, `transaction_type`, count(`ftrans_id`) AS `count_ftrans_id`, sum(`transaction_amount`) AS `sum_transaction_amount`, count(*) FILTER (WHERE `transaction_type` = 'VOID') AS `count_transaction_type_VOID`, count(*) FILTER (WHERE `transaction_type` = 'RETURN') AS `count_transaction_type_RETURN` GROUP BY `date_trunc_ymd_timestamp`, `merchant`, `implement_type`, `service`, `implement_name`, `transaction_type`"
+  },
+  "tests": [
+    {
+      "query": "SELECT merchant as dimension__alias,(count(*) FILTER(WHERE transaction_type='RETURN')) as count__alias WHERE (timestamp >= '2019-01-01') AND (timestamp < '2023-02-15') GROUP BY dimension__alias ORDER BY count__alias DESC LIMIT 15",
+      "rewrites": {
+        "r1": "SELECT c2 as dimension__alias, coalesce(sum(c10) FILTER(WHERE c6='RETURN'), 0) as count__alias WHERE (c1 >= '2019-01-01') AND (c1 < '2023-02-15') GROUP BY c2 ORDER BY coalesce(sum(c10) FILTER(WHERE c6='RETURN'), 0) DESC LIMIT 15"
+      }
+    }
+  ]
+}
+
+

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriteDateTruncViaFilter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriteDateTruncViaFilter.scala
@@ -1,58 +1,58 @@
 package com.socrata.querycoordinator
 
-class TestQueryRewriterDateTruncViaFilter extends TestQueryRewriterDateTrunc {
-  override val rewrittenQueryRymd = """
-    SELECT c2 as ward, coalesce(sum(c3)
-    FILTER (WHERE c1 BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')), 0) as count
-    GROUP BY c2"""
-
-  override val rewrittenQueryRym = """
-    SELECT c2 as ward, coalesce(sum(c3)
-    FILTER (WHERE c1 BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
-     GROUP BY c2"""
-
-  override val rewrittenQueryNotBetweenRym = """
-    SELECT c2 as ward, coalesce(sum(c3)
-    FILTER (WHERE c1 NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
-     GROUP BY c2"""
-
-  override val rewrittenQueryRy = """
-    SELECT c2 as ward, coalesce(sum(c3)
-    FILTER (WHERE c1 BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')), 0) as count
-     GROUP BY c2"""
-
-  override val qDateTruncOnLiterals = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date BETWEEN '2004-01-01' AND '2014-01-01') as count
-     GROUP BY ward"""
-
-  override val qDifferingAggregations = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date BETWEEN date_trunc_y('2004-01-01') AND date_trunc_ym('2014-01-01')) as count
-     GROUP BY ward"""
-
-  override val qDateTruncCannotBeMapped = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date BETWEEN date_trunc_y(some_date) AND date_trunc_y('2014-01-01')) as count
-     GROUP BY ward"""
-
-  override val qBetweenDateTruncYmd = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')) AS count
-     GROUP BY ward"""
-
-  override val qBetweenDateTruncYm = """
-     SELECT ward, count(*)
-     FILTER (WHERE crime_date BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
-      GROUP BY ward"""
-
-  override val qBetweenDateTruncY = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')) AS count
-     GROUP BY ward"""
-
-  override val qNotBetweenDateTruncYm = """
-    SELECT ward, count(*)
-    FILTER (WHERE crime_date NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
-     GROUP BY ward"""
-}
+//class TestQueryRewriterDateTruncViaFilter extends TestQueryRewriterDateTrunc {
+//  override val rewrittenQueryRymd = """
+//    SELECT c2 as ward, coalesce(sum(c3)
+//    FILTER (WHERE c1 BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')), 0) as count
+//    GROUP BY c2"""
+//
+//  override val rewrittenQueryRym = """
+//    SELECT c2 as ward, coalesce(sum(c3)
+//    FILTER (WHERE c1 BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
+//     GROUP BY c2"""
+//
+//  override val rewrittenQueryNotBetweenRym = """
+//    SELECT c2 as ward, coalesce(sum(c3)
+//    FILTER (WHERE c1 NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
+//     GROUP BY c2"""
+//
+//  override val rewrittenQueryRy = """
+//    SELECT c2 as ward, coalesce(sum(c3)
+//    FILTER (WHERE c1 BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')), 0) as count
+//     GROUP BY c2"""
+//
+//  override val qDateTruncOnLiterals = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date BETWEEN '2004-01-01' AND '2014-01-01') as count
+//     GROUP BY ward"""
+//
+//  override val qDifferingAggregations = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date BETWEEN date_trunc_y('2004-01-01') AND date_trunc_ym('2014-01-01')) as count
+//     GROUP BY ward"""
+//
+//  override val qDateTruncCannotBeMapped = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date BETWEEN date_trunc_y(some_date) AND date_trunc_y('2014-01-01')) as count
+//     GROUP BY ward"""
+//
+//  override val qBetweenDateTruncYmd = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')) AS count
+//     GROUP BY ward"""
+//
+//  override val qBetweenDateTruncYm = """
+//     SELECT ward, count(*)
+//     FILTER (WHERE crime_date BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
+//      GROUP BY ward"""
+//
+//  override val qBetweenDateTruncY = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')) AS count
+//     GROUP BY ward"""
+//
+//  override val qNotBetweenDateTruncYm = """
+//    SELECT ward, count(*)
+//    FILTER (WHERE crime_date NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
+//     GROUP BY ward"""
+//}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriteDateTruncViaFilter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriteDateTruncViaFilter.scala
@@ -1,58 +1,58 @@
 package com.socrata.querycoordinator
 
-//class TestQueryRewriterDateTruncViaFilter extends TestQueryRewriterDateTrunc {
-//  override val rewrittenQueryRymd = """
-//    SELECT c2 as ward, coalesce(sum(c3)
-//    FILTER (WHERE c1 BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')), 0) as count
-//    GROUP BY c2"""
-//
-//  override val rewrittenQueryRym = """
-//    SELECT c2 as ward, coalesce(sum(c3)
-//    FILTER (WHERE c1 BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
-//     GROUP BY c2"""
-//
-//  override val rewrittenQueryNotBetweenRym = """
-//    SELECT c2 as ward, coalesce(sum(c3)
-//    FILTER (WHERE c1 NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
-//     GROUP BY c2"""
-//
-//  override val rewrittenQueryRy = """
-//    SELECT c2 as ward, coalesce(sum(c3)
-//    FILTER (WHERE c1 BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')), 0) as count
-//     GROUP BY c2"""
-//
-//  override val qDateTruncOnLiterals = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date BETWEEN '2004-01-01' AND '2014-01-01') as count
-//     GROUP BY ward"""
-//
-//  override val qDifferingAggregations = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date BETWEEN date_trunc_y('2004-01-01') AND date_trunc_ym('2014-01-01')) as count
-//     GROUP BY ward"""
-//
-//  override val qDateTruncCannotBeMapped = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date BETWEEN date_trunc_y(some_date) AND date_trunc_y('2014-01-01')) as count
-//     GROUP BY ward"""
-//
-//  override val qBetweenDateTruncYmd = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')) AS count
-//     GROUP BY ward"""
-//
-//  override val qBetweenDateTruncYm = """
-//     SELECT ward, count(*)
-//     FILTER (WHERE crime_date BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
-//      GROUP BY ward"""
-//
-//  override val qBetweenDateTruncY = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')) AS count
-//     GROUP BY ward"""
-//
-//  override val qNotBetweenDateTruncYm = """
-//    SELECT ward, count(*)
-//    FILTER (WHERE crime_date NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
-//     GROUP BY ward"""
-//}
+class TestQueryRewriterDateTruncViaFilter extends TestQueryRewriterDateTrunc {
+  override val rewrittenQueryRymd = """
+    SELECT c2 as ward, coalesce(sum(c3)
+    FILTER (WHERE c1 BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')), 0) as count
+    GROUP BY c2"""
+
+  override val rewrittenQueryRym = """
+    SELECT c2 as ward, coalesce(sum(c3)
+    FILTER (WHERE c1 BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
+     GROUP BY c2"""
+
+  override val rewrittenQueryNotBetweenRym = """
+    SELECT c2 as ward, coalesce(sum(c3)
+    FILTER (WHERE c1 NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')), 0) as count
+     GROUP BY c2"""
+
+  override val rewrittenQueryRy = """
+    SELECT c2 as ward, coalesce(sum(c3)
+    FILTER (WHERE c1 BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')), 0) as count
+     GROUP BY c2"""
+
+  override val qDateTruncOnLiterals = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date BETWEEN '2004-01-01' AND '2014-01-01') as count
+     GROUP BY ward"""
+
+  override val qDifferingAggregations = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date BETWEEN date_trunc_y('2004-01-01') AND date_trunc_ym('2014-01-01')) as count
+     GROUP BY ward"""
+
+  override val qDateTruncCannotBeMapped = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date BETWEEN date_trunc_y(some_date) AND date_trunc_y('2014-01-01')) as count
+     GROUP BY ward"""
+
+  override val qBetweenDateTruncYmd = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date BETWEEN date_trunc_ymd('2011-02-01') AND date_trunc_ymd('2012-05-02')) AS count
+     GROUP BY ward"""
+
+  override val qBetweenDateTruncYm = """
+     SELECT ward, count(*)
+     FILTER (WHERE crime_date BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
+      GROUP BY ward"""
+
+  override val qBetweenDateTruncY = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date BETWEEN date_trunc_y('2011-02-01') AND date_trunc_y('2012-05-02')) AS count
+     GROUP BY ward"""
+
+  override val qNotBetweenDateTruncYm = """
+    SELECT ward, count(*)
+    FILTER (WHERE crime_date NOT BETWEEN date_trunc_ym('2011-02-01') AND date_trunc_ym('2012-05-02')) AS count
+     GROUP BY ward"""
+}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
@@ -218,4 +218,8 @@ class TestRollupQueryRewriter extends BaseConfigurableRollupTest {
     loadAndRunTests("rollups/query_rewriter_test_configs/test_derived_view_join.json")
   }
 
+  test("filtering") {
+    loadAndRunTests("rollups/query_rewriter_test_configs/test_filtering.json")
+  }
+
 }


### PR DESCRIPTION
FILTER clause is ignored in matching count() columns in rollups, which reals to incorrect matching.