### PR TITLE
do not fail when rollup is missing window function expression

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
@@ -5,7 +5,7 @@ import com.socrata.querycoordinator.rollups.QueryRewriterImplementation.{Functio
 import com.socrata.querycoordinator.util.Join.NoQualifier
 import com.socrata.soql.typed
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /*
 This class handles a specific case of the ExpressionRewriter where we know that all clauses (where/groupby/having) match,
@@ -24,7 +24,11 @@ class ClauseAwareExpressionRewriter(override val rollupColumnId: (Int) => String
    override def apply(e: Expr, r: Analysis, rollupColIdx: Map[Expr, Int]): Option[Expr] = {
     e match{
       case fc: FunctionCall if fc.window.nonEmpty =>
-        Try(Some(typed.ColumnRef(NoQualifier, rollupColumnId(rollupColIdx(fc)), fc.typ)(fc.position))).getOrElse(None)
+        Try(rollupColIdx(fc))match{
+          case Success(remappedColumn)=>Some(typed.ColumnRef(NoQualifier, rollupColumnId(remappedColumn), fc.typ)(fc.position))
+          case Failure(e:NoSuchElementException)=>None
+          case Failure(e)=> throw e
+        }
       case _=>
         super.apply(e, r, rollupColIdx)
     }

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
@@ -5,6 +5,8 @@ import com.socrata.querycoordinator.rollups.QueryRewriterImplementation.{Functio
 import com.socrata.querycoordinator.util.Join.NoQualifier
 import com.socrata.soql.typed
 
+import scala.util.Try
+
 /*
 This class handles a specific case of the ExpressionRewriter where we know that all clauses (where/groupby/having) match,
 so therefor we want to rewrite the window functions.
@@ -22,7 +24,7 @@ class ClauseAwareExpressionRewriter(override val rollupColumnId: (Int) => String
    override def apply(e: Expr, r: Analysis, rollupColIdx: Map[Expr, Int]): Option[Expr] = {
     e match{
       case fc: FunctionCall if fc.window.nonEmpty =>
-        Some(typed.ColumnRef(NoQualifier, rollupColumnId(rollupColIdx(fc)), fc.typ)(fc.position))
+        Try(Some(typed.ColumnRef(NoQualifier, rollupColumnId(rollupColIdx(fc)), fc.typ)(fc.position))).getOrElse(None)
       case _=>
         super.apply(e, r, rollupColIdx)
     }

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClauseAwareExpressionRewriter.scala
@@ -5,8 +5,6 @@ import com.socrata.querycoordinator.rollups.QueryRewriterImplementation.{Functio
 import com.socrata.querycoordinator.util.Join.NoQualifier
 import com.socrata.soql.typed
 
-import scala.util.{Failure, Success, Try}
-
 /*
 This class handles a specific case of the ExpressionRewriter where we know that all clauses (where/groupby/having) match,
 so therefor we want to rewrite the window functions.
@@ -16,20 +14,16 @@ The decision of which class to use is made in com.socrata.querycoordinator.rollu
 class ClauseAwareExpressionRewriter(override val rollupColumnId: (Int) => String,
                                     override val rewriteWhere: (Option[Expr], Analysis, Map[Expr, Int]) => Option[Where]) extends ExpressionRewriter(rollupColumnId, rewriteWhere) {
   /** Recursively maps the Expr based on the rollupColIdx map, returning either
-   * a mapped expression or None if the expression couldn't be mapped.
-   *
-   * Note that every case here needs to ensure to map every expression recursively
-   * to ensure it is either a literal or mapped to the rollup.
-   */
-   override def apply(e: Expr, r: Analysis, rollupColIdx: Map[Expr, Int]): Option[Expr] = {
-    e match{
+    * a mapped expression or None if the expression couldn't be mapped.
+    *
+    * Note that every case here needs to ensure to map every expression recursively
+    * to ensure it is either a literal or mapped to the rollup.
+    */
+  override def apply(e: Expr, r: Analysis, rollupColIdx: Map[Expr, Int]): Option[Expr] = {
+    e match {
       case fc: FunctionCall if fc.window.nonEmpty =>
-        Try(rollupColIdx(fc))match{
-          case Success(remappedColumn)=>Some(typed.ColumnRef(NoQualifier, rollupColumnId(remappedColumn), fc.typ)(fc.position))
-          case Failure(e:NoSuchElementException)=>None
-          case Failure(e)=> throw e
-        }
-      case _=>
+        rollupColIdx.get(fc).map(cid => typed.ColumnRef(NoQualifier, rollupColumnId(cid), fc.typ)(fc.position))
+      case _ =>
         super.apply(e, r, rollupColIdx)
     }
   }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWindowFunctionTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWindowFunctionTest.scala
@@ -1,13 +1,13 @@
 package com.socrata.querycoordinator
 
 import com.socrata.querycoordinator.QueryRewritingTestUtility._
-import com.socrata.soql.types.{SoQLDate, SoQLNumber, SoQLText}
+import com.socrata.soql.types.{SoQLNumber, SoQLText}
 import org.scalatest.FunSuite
 
 class QueryRewriterWindowFunctionTest extends FunSuite {
 
   test("Window function should rewrite when there are no clauses") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -26,7 +26,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Window function should rewrite when where clauses match") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -45,7 +45,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Mismatch of query where clause with window function should not rewrite") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -64,7 +64,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Mismatch of rollup where clause with window function should not rewrite") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -84,7 +84,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
 
 
   test("Window function should rewrite when groupby clauses match") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -103,7 +103,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Mismatch of groupby with window function should not rewrite") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -123,7 +123,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
 
 
   test("Window function should rewrite when having clauses match") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -142,7 +142,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Mismatch having clause with window function should not rewrite") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -162,7 +162,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
 
 
   test("Window function should rewrite when there are no clauses and its not top level") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(
@@ -181,7 +181,7 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
   }
 
   test("Rewrite a query with a window function when no rollups have a window function, should not rewrite") {
-    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+
     AssertRewriteDefault(
       Map(
         "_" -> Map(

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWindowFunctionTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWindowFunctionTest.scala
@@ -180,5 +180,23 @@ class QueryRewriterWindowFunctionTest extends FunSuite {
     )
   }
 
+  test("Rewrite a query with a window function when no rollups have a window function, should not rewrite") {
+    // Assumes a default setup, ie.. SoQLAnalyzer/AbstractParser.Parameters/Parser/QueryRewriter
+    AssertRewriteDefault(
+      Map(
+        "_" -> Map(
+          "depname_column" -> (SoQLText.t, "depname"),
+          "empno_column" -> (SoQLNumber.t, "empno"),
+          "salary_column" -> (SoQLNumber.t, "salary")
+        )
+      ),
+      Map(
+        "one" -> "SELECT depname, empno, sum(salary) as salarySum group by depname,empno"
+      ),
+      "SELECT depname, empno, salary, avg(salary) OVER (PARTITION BY depname) as avgSalary",
+      "SELECT depname, empno, salary, avg(salary) OVER (PARTITION BY depname) as avgSalary",
+      None
+    )
+  }
 
 }


### PR DESCRIPTION
Right, we should not assume rewriting is successful.
Need to wrap that new window function path in a try.