### PR TITLE
Piped query rewriting fix

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -338,7 +338,9 @@ class QueryResource(secondary: Secondary,
                 val (nr, rollupJoin) = possiblyRewriteJoin(r)
                 val (nr2, rollupRight) = possiblyRewriteOneAnalysisInQuery(schema, nr, Some(ruMap))
                 val rewritten = ((rollupLeft,rollupJoin,rollupRight)match{
+                  //If Join or Right are rewritten, then its officially the "right" side, only right matters
                   case (Nil,Nil,Seq(_)) | (Nil,Seq(_),Nil) | (Nil,Seq(_),Seq(_))=>nr2
+                  //Else left was rewritten, but we want to return a PipQuery because there are still further expressions acting
                   case _=>PipeQuery(nl,nr2)
                 }, rollupLeft ++ rollupRight ++ rollupJoin)
                 if (ruMapOpt.isEmpty && ruMap.nonEmpty && (rollupLeft.isEmpty&&rollupRight.isEmpty&&rollupJoin.isEmpty)) {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -67,17 +67,17 @@ object QueryRewriter {
       ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
     )
   }
+
   def doMerge(analysisTree: BinaryTree[SoQLAnalysis[ColumnName, SoQLType]]): BinaryTree[SoQLAnalysis[ColumnName, SoQLType]] = {
     SoQLAnalysis.merge(
       SoQLFunctions.And.monomorphic.get,
       analysisTree
-    )match {
-      case x@PipeQuery(y@PipeQuery(_, _), r) => doMerge(PipeQuery(doMerge(y),r))
-      case a => a
+    ) match {
+      case PipeQuery(l @ PipeQuery(_, _), r) =>
+        doMerge(PipeQuery(doMerge(l), r))
+      case other => other
     }
   }
-
-  //x=>doMerge(Leaf(x)).outputSchema.leaf
 
 
   def primaryRollup(names: Seq[String]): Option[String] = {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -3,9 +3,10 @@ package com.socrata.querycoordinator.rollups
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, AnalysisTree, Expr, RollupName}
 import com.socrata.querycoordinator.util.BinaryTreeHelper
 import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
+import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.{ColumnName, TableName}
 import com.socrata.soql.functions.SoQLFunctions
-import com.socrata.soql.{BinaryTree, Leaf, PipeQuery, SoQLAnalysis}
+import com.socrata.soql.{BinaryTree, Leaf, PipeQuery, SoQLAnalysis, typed}
 import com.socrata.soql.types.SoQLType
 
 /**
@@ -61,11 +62,39 @@ object QueryRewriter {
     * Merge rollups analysis
     */
   def mergeRollupsAnalysis(rus: Map[RollupName, AnalysisTree]): Map[RollupName, Analysis] = {
-    rus.mapValues(bt =>
-      doMerge(
+    rus.mapValues { bt =>
+      val merged = doMerge(
         bt.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId)))
-      ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
-    )
+      )
+
+      val mergedAgain = SoQLAnalysis.merge(
+        SoQLFunctions.And.monomorphic.get,
+        merged
+      )
+//
+//      val mergedMap = merged match {
+//        case PipeQuery(l, r) =>
+//          l.outputSchema.leaf.selection.foreach { case (b,c) =>
+//            BinaryTreeHelper.replace(r, r.outputSchema.leaf, r.outputSchema.leaf.copy(selection = {
+//              r.outputSchema.leaf.selection.map(doRemap(l.outputSchema.leaf.selection))
+//            }))
+//          }
+//        case x => x
+//      }
+//            val mergedMap = merged match {
+//              case PipeQuery(l, r) => BinaryTreeHelper.replace(r, r.outputSchema.leaf, r.outputSchema.leaf.copy(selection = {
+//                r.outputSchema.leaf.selection.map(doRemap(l.outputSchema.leaf.selection))
+//              }))
+//              case x => x
+//            }
+
+      merged.outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
+    }
+  }
+
+  def doRemap(schema:OrderedMap[ColumnName, typed.CoreExpr[ColumnName, SoQLType]])(selection:(ColumnName, typed.CoreExpr[ColumnName, SoQLType])):(ColumnName, typed.CoreExpr[ColumnName, SoQLType])={
+    val (columnName,expression) = selection
+    ???
   }
 
   def doMerge(analysisTree: BinaryTree[SoQLAnalysis[ColumnName, SoQLType]]): BinaryTree[SoQLAnalysis[ColumnName, SoQLType]] = {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -1,10 +1,11 @@
 package com.socrata.querycoordinator.rollups
 
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, AnalysisTree, Expr, RollupName}
+import com.socrata.querycoordinator.util.BinaryTreeHelper
 import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
 import com.socrata.soql.environment.{ColumnName, TableName}
 import com.socrata.soql.functions.SoQLFunctions
-import com.socrata.soql.{BinaryTree, PipeQuery, SoQLAnalysis}
+import com.socrata.soql.{BinaryTree, Leaf, PipeQuery, SoQLAnalysis}
 import com.socrata.soql.types.SoQLType
 
 /**
@@ -70,11 +71,14 @@ object QueryRewriter {
     SoQLAnalysis.merge(
       SoQLFunctions.And.monomorphic.get,
       analysisTree
-    ) match {
-      case x@PipeQuery(PipeQuery(_,_),_) => doMerge(x)
+    )match {
+      case x@PipeQuery(y@PipeQuery(_, _), r) => doMerge(PipeQuery(doMerge(y),r))
       case a => a
     }
   }
+
+  //x=>doMerge(Leaf(x)).outputSchema.leaf
+
 
   def primaryRollup(names: Seq[String]): Option[String] = {
     names.filterNot(_.startsWith(TableName.SoqlPrefix)).headOption

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -1,12 +1,10 @@
 package com.socrata.querycoordinator.rollups
 
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, AnalysisTree, Expr, RollupName}
-import com.socrata.querycoordinator.util.BinaryTreeHelper
 import com.socrata.querycoordinator.{Schema, SchemaWithFieldName}
-import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.{ColumnName, TableName}
 import com.socrata.soql.functions.SoQLFunctions
-import com.socrata.soql.{BinaryTree, Leaf, PipeQuery, SoQLAnalysis, typed}
+import com.socrata.soql.{BinaryTree, SoQLAnalysis}
 import com.socrata.soql.types.SoQLType
 
 /**
@@ -62,52 +60,14 @@ object QueryRewriter {
     * Merge rollups analysis
     */
   def mergeRollupsAnalysis(rus: Map[RollupName, AnalysisTree]): Map[RollupName, Analysis] = {
-    rus.mapValues { bt =>
-      val merged = doMerge(
-        bt.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId)))
-      )
-
-      val mergedAgain = SoQLAnalysis.merge(
+    rus.mapValues(bt =>
+      SoQLAnalysis.merge(
         SoQLFunctions.And.monomorphic.get,
-        merged
-      )
-//
-//      val mergedMap = merged match {
-//        case PipeQuery(l, r) =>
-//          l.outputSchema.leaf.selection.foreach { case (b,c) =>
-//            BinaryTreeHelper.replace(r, r.outputSchema.leaf, r.outputSchema.leaf.copy(selection = {
-//              r.outputSchema.leaf.selection.map(doRemap(l.outputSchema.leaf.selection))
-//            }))
-//          }
-//        case x => x
-//      }
-//            val mergedMap = merged match {
-//              case PipeQuery(l, r) => BinaryTreeHelper.replace(r, r.outputSchema.leaf, r.outputSchema.leaf.copy(selection = {
-//                r.outputSchema.leaf.selection.map(doRemap(l.outputSchema.leaf.selection))
-//              }))
-//              case x => x
-//            }
-
-      merged.outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
-    }
+        bt.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId))
+        )
+      ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
+    )
   }
-
-  def doRemap(schema:OrderedMap[ColumnName, typed.CoreExpr[ColumnName, SoQLType]])(selection:(ColumnName, typed.CoreExpr[ColumnName, SoQLType])):(ColumnName, typed.CoreExpr[ColumnName, SoQLType])={
-    val (columnName,expression) = selection
-    ???
-  }
-
-  def doMerge(analysisTree: BinaryTree[SoQLAnalysis[ColumnName, SoQLType]]): BinaryTree[SoQLAnalysis[ColumnName, SoQLType]] = {
-    SoQLAnalysis.merge(
-      SoQLFunctions.And.monomorphic.get,
-      analysisTree
-    ) match {
-      case PipeQuery(l @ PipeQuery(_, _), r) =>
-        doMerge(PipeQuery(doMerge(l), r))
-      case other => other
-    }
-  }
-
 
   def primaryRollup(names: Seq[String]): Option[String] = {
     names.filterNot(_.startsWith(TableName.SoqlPrefix)).headOption


### PR DESCRIPTION
Originally we only try to rewrite the left side of a query pipe.
Recently we introduced rollups being able to use pipes.
As result we need to handle rewriting left/right better.

EN-58705
