### PR TITLE
[EN-58705] Restructuring QueryRewriter and QueryResource

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
@@ -21,7 +21,7 @@ import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
 import com.socrata.soql.types.SoQLType
 import com.socrata.soql.{AnalysisSerializer, SoQLAnalyzer}
 import com.socrata.curator.{ConfigWatch, CuratorFromConfig, DiscoveryFromConfig}
-import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation, RollupInfoFetcher}
+import com.socrata.querycoordinator.rollups.{CompoundQueryRewriter, RollupInfoFetcher}
 import com.socrata.thirdparty.metrics.{MetricsReporter, SocrataHttpSupport}
 import com.socrata.thirdparty.typesafeconfig.Propertizer
 import com.typesafe.config.{Config, ConfigFactory}
@@ -108,7 +108,7 @@ object Main extends App with DynamicPortMap {
       schemaCache = (_, _, _) => (),
       schemaDecache = (_, _) => None,
       secondaryInstance = secondaryInstanceSelector,
-      queryRewriter = new QueryRewriterImplementation(analyzer),
+      queryRewriter = new CompoundQueryRewriter(analyzer),
       rollupInfoFetcher = new RollupInfoFetcher(httpClient)
     )
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/QueryResource.scala
@@ -10,19 +10,17 @@ import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.util.RequestId
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, AnalysisTree, ColumnId, RollupName}
-import com.socrata.querycoordinator.SchemaFetcher.{BadResponseFromSecondary, NoSuchDatasetInSecondary, NonSchemaResponse, Result, SecondaryConnectFailed, Successful, TimeoutFromSecondary}
+import com.socrata.querycoordinator.SchemaFetcher.{NoSuchDatasetInSecondary, Successful, TimeoutFromSecondary}
 import com.socrata.querycoordinator._
 import com.socrata.querycoordinator.caching.SharedHandle
 import com.socrata.querycoordinator.datetime.NowAnalyzer
 import com.socrata.querycoordinator.exceptions.JoinedDatasetNotColocatedException
-import com.socrata.querycoordinator.rollups.{QueryRewriter, RollupInfoFetcher, RollupScorer}
-import com.socrata.querycoordinator.util.BinaryTreeHelper
+import com.socrata.querycoordinator.rollups.{QueryRewriter, RollupInfoFetcher, RollupInfo}
 import com.socrata.soql.environment.{ColumnName, TableName}
 import com.socrata.soql.exceptions.{DuplicateAlias, NoSuchColumn, TypecheckException}
-import com.socrata.soql.{BinaryTree, Compound, JoinAnalysis, Leaf, PipeQuery, SoQLAnalysis, SubAnalysis}
+import com.socrata.soql.{BinaryTree, SoQLAnalysis}
 import com.socrata.soql.types.{SoQLID, SoQLNumber, SoQLType}
 import com.socrata.soql.stdlib.Context
-import com.socrata.soql.typed.{Join, RollupAtJoin}
 import org.apache.http.HttpStatus
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone, Interval}
@@ -303,152 +301,38 @@ class QueryResource(secondary: Secondary,
           }
         }
 
+        def fetchRollupInfo(): Seq[RollupInfo] = rollupInfoFetcher(base.receiveTimeoutMS(schemaTimeout.toMillis.toInt), Left(dataset), copy) match {
+          case RollupInfoFetcher.Successful(rollups) =>
+            rollups
+          case RollupInfoFetcher.NoSuchDatasetInSecondary =>
+            chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
+            finishRequest(notFoundResponse(dataset))
+          case RollupInfoFetcher.TimeoutFromSecondary =>
+            chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
+            finishRequest(upstreamTimeoutResponse)
+          case other: RollupInfoFetcher.Result =>
+            log.error(unexpectedError, other)
+            chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
+            finishRequest(internalServerError)
+          case unsuccessful =>
+            log.warn(s"No rollups ${dataset} ${unsuccessful.toString}")
+            Seq.empty
+        }
+
         /**
          * Scan from left to right (inner to outer), rewrite the first possible one.
          * TODO: Find a better way to apply rollup?
          */
         def possiblyRewriteOneAnalysisInQuery(schema: Schema, analyzedQuery: BinaryTree[SoQLAnalysis[String, SoQLType]],
                                               ruMapOpt: Option[Map[RollupName, AnalysisTree]] = None):
-            (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String]) = {
-
+        (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String]) = {
           if (noRollup) {
             (analyzedQuery, Seq.empty)
           } else {
-            val ruMap: Map[RollupName, AnalysisTree] = ruMapOpt.getOrElse(
-              rollupInfoFetcher(base.receiveTimeoutMS(schemaTimeout.toMillis.toInt), Left(dataset), copy) match {
-                case RollupInfoFetcher.Successful(rollups) =>
-                  queryRewriter.analyzeRollups(schema, rollups, getSchemaByTableName)
-                case RollupInfoFetcher.NoSuchDatasetInSecondary =>
-                  chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
-                  finishRequest(notFoundResponse(dataset))
-                case RollupInfoFetcher.TimeoutFromSecondary =>
-                  chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
-                  finishRequest(upstreamTimeoutResponse)
-                case other: RollupInfoFetcher.Result =>
-                  log.error(unexpectedError, other)
-                  chosenSecondaryName.foreach { n => secondaryInstance.flagError(dataset, n) }
-                  finishRequest(internalServerError)
-                case unsuccessful =>
-                  log.warn(s"No rollups ${dataset} ${unsuccessful.toString}")
-                  Map.empty
-              })
-            analyzedQuery match {
-              case PipeQuery(l, r) =>
-                val (nl, rollupLeft) = possiblyRewriteOneAnalysisInQuery(schema, l, Some(ruMap))
-                val (nr, rollupJoin) = possiblyRewriteJoin(r)
-                val rewritten = (PipeQuery(nl, nr), rollupLeft ++ rollupJoin)
-                if (ruMapOpt.isEmpty && ruMap.nonEmpty && rollupLeft.isEmpty) {
-                  // simple rewrite has higher priority over compound query rewrite
-                  // for fear that compound rewrite is not as matured as simple rewrite
-                  queryRewriter.possibleRewrites(analyzedQuery, ruMap, true)
-                } else {
-                  rewritten
-                }
-              case Compound(_, _, _) =>
-                if (ruMapOpt.isEmpty && ruMap.nonEmpty) {
-                  queryRewriter.possibleRewrites(analyzedQuery, ruMap, true) match {
-                    case (unchanged, Nil) =>
-                      possiblyRewriteJoin(unchanged)
-                    case rewritten@(_, _) =>
-                      rewritten
-                  }
-                } else {
-                  possiblyRewriteJoin(analyzedQuery)
-                }
-              case Leaf(analysis) =>
-                val (schemaFrom, datasetOrResourceName) = analysis.from match {
-                  case Some(TableName(TableName.This, _)) =>
-                    (schema, Left(dataset))
-                  case Some(tableName@TableName(TableName.SingleRow, _)) =>
-                    (Schema.SingleRow, Right(tableName.name))
-                  case Some(tableName) =>
-                    val schemaWithFieldName = getSchemaByTableName(tableName)
-                    (schemaWithFieldName.toSchema(), Right(tableName.name))
-                  case None =>
-                    (schema, Left(dataset))
-                }
-
-                datasetOrResourceName match {
-                  case Left(dataset) =>
-                    val rus = QueryRewriter.mergeRollupsAnalysis(ruMap)
-                    // Only the leftmost soql in a chain can use rollups.
-                    possiblyRewriteQuery(analysis, rus) match {
-                      case (rewrittenAnal, ru@Some(_)) =>
-                        (Leaf(rewrittenAnal), ru.toSeq)
-                      case (_, None) =>
-                        val (possiblyRewrittenAnalysis, rollupJoin) = possiblyRewriteJoin(analysis)
-                        (Leaf(possiblyRewrittenAnalysis), rollupJoin)
-                    }
-                  case Right(resourceName) =>
-                    // TODO: union cannot use RollUp yet.
-                    // Further work needs to decorate the analysis with more than one rollup info so that
-                    // soql-postgres-adapter can get to the rollup table name.
-                    // Options to put the additional rollups info -
-                    // 1. Request Header
-                    // 2. in Analysis.from
-                    (Leaf(analysis), Seq.empty)
-                }
-            }
+            queryRewriter.possiblyRewriteOneAnalysisInQuery(
+              dataset, schema, analyzedQuery, ruMapOpt, fetchRollupInfo, getSchemaByTableName, debug
+            )
           }
-        }
-
-        def possiblyRewriteJoin(analyses: BinaryTree[SoQLAnalysis[String, SoQLType]]): (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String]) = {
-          analyses match {
-            case Compound(op, l, r) =>
-              val (nl, rul) = possiblyRewriteJoin(l)
-              val (nr, rur) = possiblyRewriteJoin(r)
-              (Compound(op, nl, nr), rul ++ rur)
-            case Leaf(l) =>
-              val (nl, ru) = possiblyRewriteJoin(l)
-              (Leaf(nl), ru)
-          }
-        }
-
-        def possiblyRewriteJoin(analysis: SoQLAnalysis[String, SoQLType]): (SoQLAnalysis[String, SoQLType], Seq[String]) = {
-          if (!QueryRewriter.rollupAtJoin(analysis)) {
-            return (analysis, Nil)
-          }
-
-          val (rwJoins, rus) = analysis.joins.foldLeft((Seq.empty[Join[String, SoQLType]], Seq.empty[String])) { (acc, join) =>
-            join.from.subAnalysis match {
-              case Right(SubAnalysis(analyses, alias)) =>
-                val leftMost = analyses.leftMost
-                val leftMostFromRemoved = Leaf(leftMost.leaf.copy(from = None))
-                val joinedAnalysesFromRemoved = analyses.replace(leftMost, leftMostFromRemoved)
-                val joinedTable = leftMost.leaf.from.get
-                rollupInfoFetcher(base.receiveTimeoutMS(schemaTimeout.toMillis.toInt), Right(joinedTable.name), copy) match {
-                  case RollupInfoFetcher.Successful(rollups) =>
-                    val joinedSchema = getSchemaByTableName(joinedTable)
-                    val analyzedRollupsOfJoinTable = queryRewriter.analyzeRollups(joinedSchema.toSchema(), rollups, getSchemaByTableName)
-                    queryRewriter.possibleRewrites(joinedAnalysesFromRemoved, analyzedRollupsOfJoinTable, false) match {
-                      case (rwAnalyses, Seq(ruApplied)) =>
-                        val ruTableName = TableName(s"${joinedTable.name}.${ruApplied}")
-                        val rwAnalysesRollupTableApplied = rwAnalyses.leftMost.leaf.copy(from = Some(ruTableName))
-                        val rwSubAnalysis = SubAnalysis(Leaf(rwAnalysesRollupTableApplied), alias)
-                        val rwJoinJoinAnalysis: JoinAnalysis[ColumnId, SoQLType] = join.from.copy(subAnalysis = Right(rwSubAnalysis))
-                        val rwJoin = join.copy(from = rwJoinJoinAnalysis)
-                        (acc._1 :+ rwJoin, acc._2 :+ ruTableName.nameWithSoqlPrefix)
-                      case _ =>
-                        (acc._1 :+ join, acc._2)
-                    }
-                  case _ =>
-                    (acc._1 :+ join, acc._2)
-                }
-              case _ =>
-                (acc._1 :+ join, acc._2)
-            }
-          }
-          (analysis.copy(joins = rwJoins), rus)
-        }
-
-        def possiblyRewriteQuery(analyzedQuery: SoQLAnalysis[String, SoQLType], rollups: Map[RollupName, Analysis]):
-          (SoQLAnalysis[String, SoQLType], Option[String]) = {
-          val rewritten = queryRewriter.bestRollup(
-            queryRewriter.possibleRewrites(analyzedQuery, rollups, debug).toSeq)
-          val (rollupName, analysis) = rewritten map { x => (Option(x._1), x._2) } getOrElse ((None, analyzedQuery))
-          rollupName.foreach(ru => log.info(s"Rewrote query on dataset $dataset to rollup $ru")) // only log rollup name if it is defined.
-          log.debug(s"Rewritten analysis: $analysis")
-          (analysis, rollupName)
         }
 
         case class Versioned[T](payload: T, copyNumber: Long, dataVersion: Long, lastModified: DateTime)

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClausesMatchedExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ClausesMatchedExpressionRewriter.scala
@@ -1,7 +1,7 @@
 package com.socrata.querycoordinator.rollups
 
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, Expr}
-import com.socrata.querycoordinator.rollups.QueryRewriterImplementation.{FunctionCall, Where}
+import com.socrata.querycoordinator.rollups.BaseQueryRewriter.{FunctionCall, Where}
 import com.socrata.querycoordinator.util.Join.NoQualifier
 import com.socrata.soql.typed
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/CompoundQueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/CompoundQueryRewriter.scala
@@ -1,15 +1,156 @@
 package com.socrata.querycoordinator.rollups
 
+
+
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, AnalysisTree, ColumnId, RollupName}
+import com.socrata.soql._
+import com.socrata.soql.environment.{ColumnName, TableName}
 import com.socrata.soql.typed.{ColumnRef, CompoundRollup, Indistinct}
-import com.socrata.soql.types.SoQLType
-import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery}
+import com.socrata.soql.types.{SoQLType, SoQLValue}
+import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery, SoQLAnalyzer}
+import com.socrata.querycoordinator._
+
 
 /**
   * Rewrite compound query with either exact tree match or prefix tree match
   * TODO: Make matching more flexible.  e.g. "SELECT a, b" does not match "SELECT b, a" or "SELECT a"
   */
-trait CompoundQueryRewriter { this: QueryRewriterImplementation =>
+class CompoundQueryRewriter(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) extends BaseQueryRewriter(analyzer) with QueryRewriter {
+
+
+  def possiblyRewriteOneAnalysisInQuery(dataset: String,
+                                        schema: Schema,
+                                        analyzedQuery: BinaryTree[SoQLAnalysis[String, SoQLType]],
+                                        ruMapOpt: Option[Map[RollupName, AnalysisTree]],
+                                        rollupFetcher: () => Seq[RollupInfo],
+                                        schemaFetcher: TableName => SchemaWithFieldName,
+                                        debug: Boolean):
+  (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String]) = {
+
+    val ruMap: Map[RollupName, AnalysisTree] = ruMapOpt.getOrElse(rollupFetcher() match {
+      case Seq() => Map.empty
+      case rollups => analyzeRollups(schema, rollups, schemaFetcher)
+    })
+
+    analyzedQuery match {
+      case PipeQuery(l, r) =>
+        val (nl, rollupLeft) = possiblyRewriteOneAnalysisInQuery(
+          dataset, schema, l, Some(ruMap), rollupFetcher, schemaFetcher, debug
+        )
+        val (nr, rollupJoin) = possiblyRewriteJoin(r, rollupFetcher, schemaFetcher)
+        val rewritten = (PipeQuery(nl, nr), rollupLeft ++ rollupJoin)
+        if (ruMapOpt.isEmpty && ruMap.nonEmpty && rollupLeft.isEmpty) {
+          // simple rewrite has higher priority over compound query rewrite
+          // for fear that compound rewrite is not as matured as simple rewrite
+          possibleRewrites(analyzedQuery, ruMap, true)
+        } else {
+          rewritten
+        }
+      case Compound(_, _, _) =>
+        if (ruMapOpt.isEmpty && ruMap.nonEmpty) {
+          possibleRewrites(analyzedQuery, ruMap, true) match {
+            case (unchanged, Nil) =>
+              possiblyRewriteJoin(unchanged, rollupFetcher, schemaFetcher)
+            case rewritten@(_, _) =>
+              rewritten
+          }
+        } else {
+          possiblyRewriteJoin(analyzedQuery, rollupFetcher, schemaFetcher)
+        }
+      case Leaf(analysis) =>
+        val (schemaFrom, datasetOrResourceName) = analysis.from match {
+          case Some(TableName(TableName.This, _)) =>
+            (schema, Left(dataset))
+          case Some(tableName@TableName(TableName.SingleRow, _)) =>
+            (Schema.SingleRow, Right(tableName.name))
+          case Some(tableName) =>
+            val schemaWithFieldName = schemaFetcher(tableName)
+            (schemaWithFieldName.toSchema(), Right(tableName.name))
+          case None =>
+            (schema, Left(dataset))
+        }
+
+        datasetOrResourceName match {
+          case Left(dataset) =>
+            val rus = QueryRewriter.mergeRollupsAnalysis(ruMap)
+            // Only the leftmost soql in a chain can use rollups.
+            possiblyRewriteQuery(dataset, analysis, rus, debug) match {
+              case (rewrittenAnal, ru@Some(_)) =>
+                (Leaf(rewrittenAnal), ru.toSeq)
+              case (_, None) =>
+                val (possiblyRewrittenAnalysis, rollupJoin) = possiblyRewriteJoin(analysis, rollupFetcher, schemaFetcher)
+                (Leaf(possiblyRewrittenAnalysis), rollupJoin)
+            }
+          case Right(resourceName) =>
+            // TODO: union cannot use RollUp yet.
+            // Further work needs to decorate the analysis with more than one rollup info so that
+            // soql-postgres-adapter can get to the rollup table name.
+            // Options to put the additional rollups info -
+            // 1. Request Header
+            // 2. in Analysis.from
+            (Leaf(analysis), Seq.empty)
+        }
+    }
+  }
+
+  def possiblyRewriteJoin(analyses: BinaryTree[SoQLAnalysis[String, SoQLType]],
+                          rollupFetcher: () => Seq[RollupInfo],
+                          schemaFetcher: TableName => SchemaWithFieldName):
+  (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String]) = {
+
+    analyses match {
+      case Compound(op, l, r) =>
+        val (nl, rul) = possiblyRewriteJoin(l, rollupFetcher, schemaFetcher)
+        val (nr, rur) = possiblyRewriteJoin(r, rollupFetcher, schemaFetcher)
+        (Compound(op, nl, nr), rul ++ rur)
+      case Leaf(l) =>
+        val (nl, ru) = possiblyRewriteJoin(l, rollupFetcher, schemaFetcher)
+        (Leaf(nl), ru)
+    }
+  }
+
+  def possiblyRewriteJoin(analysis: SoQLAnalysis[String, SoQLType],
+                          rollupFetcher: () => Seq[RollupInfo],
+                          schemaFetcher: TableName => SchemaWithFieldName):
+  (SoQLAnalysis[String, SoQLType], Seq[String]) = {
+
+    if (!QueryRewriter.rollupAtJoin(analysis)) {
+      return (analysis, Nil)
+    }
+
+    val (rwJoins, rus) = analysis.joins.foldLeft((Seq.empty[typed.Join[String, SoQLType]], Seq.empty[String])) { (acc, join) =>
+      join.from.subAnalysis match {
+        case Right(SubAnalysis(analyses, alias)) =>
+          val leftMost = analyses.leftMost
+          val leftMostFromRemoved = Leaf(leftMost.leaf.copy(from = None))
+          val joinedAnalysesFromRemoved = analyses.replace(leftMost, leftMostFromRemoved)
+          val joinedTable = leftMost.leaf.from.get
+
+          rollupFetcher() match {
+            case Seq() =>
+              (acc._1 :+ join, acc._2)
+            case rollups =>
+              val joinedSchema = schemaFetcher(joinedTable)
+              val analyzedRollupsOfJoinTable = analyzeRollups(joinedSchema.toSchema(), rollups, schemaFetcher)
+              possibleRewrites(joinedAnalysesFromRemoved, analyzedRollupsOfJoinTable, false) match {
+                case (rwAnalyses, Seq(ruApplied)) =>
+                  val ruTableName = TableName(s"${joinedTable.name}.${ruApplied}")
+                  val rwAnalysesRollupTableApplied = rwAnalyses.leftMost.leaf.copy(from = Some(ruTableName))
+                  val rwSubAnalysis = SubAnalysis(Leaf(rwAnalysesRollupTableApplied), alias)
+                  val rwJoinJoinAnalysis: JoinAnalysis[ColumnId, SoQLType] = join.from.copy(subAnalysis = Right(rwSubAnalysis))
+                  val rwJoin = join.copy(from = rwJoinJoinAnalysis)
+                  (acc._1 :+ rwJoin, acc._2 :+ ruTableName.nameWithSoqlPrefix)
+                case _ =>
+                  (acc._1 :+ join, acc._2)
+              }
+
+          }
+        case _ =>
+          (acc._1 :+ join, acc._2)
+      }
+    }
+    (analysis.copy(joins = rwJoins), rus)
+  }
 
   /**
     * The tree q is successfully rewritten and returned in the first tuple element if

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/ExpressionRewriter.scala
@@ -6,7 +6,7 @@ import com.socrata.soql.functions.SoQLFunctions._
 import com.socrata.soql.types._
 import com.socrata.querycoordinator.rollups.ExpressionRewriter._
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, Expr, ColumnId}
-import com.socrata.querycoordinator.rollups.QueryRewriterImplementation._
+import com.socrata.querycoordinator.rollups.BaseQueryRewriter._
 import com.socrata.soql.typed.{ColumnRef => _, FunctionCall => _, Join => _, OrderBy => _, _}
 
 import org.joda.time.{DateTimeConstants, LocalDateTime}

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -13,30 +13,16 @@ import com.socrata.soql.types.SoQLType
   *
   * Any class wishing to use the QueryRewriter must use the interface, not a concrete implementation.
   */
-abstract class QueryRewriter {
+trait QueryRewriter {
 
-  /**
-    * *Map rollup definitions into query analysis in schema context
-    *
-    * ToDo: Should this return merged analysis?
-    *
-    */
-  def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
-                     getSchemaByTableName: TableName => SchemaWithFieldName): Map[RollupName, AnalysisTree]
-
-  /**
-    * Creates possible rewrites for the query given the rollups
-    *
-    */
-  def possibleRewrites(q: Analysis, rollups: Map[RollupName, Analysis]): Map[RollupName, Analysis]
-  def possibleRewrites(q: AnalysisTree, rollups: Map[RollupName, AnalysisTree], requireCompoundRollupHint: Boolean): (AnalysisTree, Seq[String])
-  def possibleRewrites(q: Analysis, rollups: Map[RollupName, Analysis], debug: Boolean): Map[RollupName, Analysis]
-
-  /**
-    * Returns best scored rollup
-    *
-    */
-  def bestRollup(rollups: Seq[(RollupName, Analysis)]): Option[(RollupName, Analysis)]
+  def possiblyRewriteOneAnalysisInQuery(dataset: String,
+                                        schema: Schema,
+                                        analyzedQuery: BinaryTree[SoQLAnalysis[String, SoQLType]],
+                                        ruMapOpt: Option[Map[RollupName, AnalysisTree]],
+                                        ruFetcher: () => Seq[RollupInfo],
+                                        schemaFetcher: TableName => SchemaWithFieldName,
+                                        debug: Boolean):
+  (BinaryTree[SoQLAnalysis[String, SoQLType]], Seq[String])
 
 }
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/RollupScorer.scala
@@ -26,7 +26,7 @@ import com.typesafe.scalalogging.Logger
  *
  */
 import com.socrata.querycoordinator.rollups.QueryRewriter._
-import com.socrata.querycoordinator.rollups.QueryRewriterImplementation._
+import com.socrata.querycoordinator.rollups.BaseQueryRewriter._
 
 
 private final abstract class RollupScorer

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewriterWithJoinEnabled.scala
@@ -1,12 +1,13 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.rollups.{QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.CompoundQueryRewriter
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, RollupName}
 import com.socrata.soql.SoQLAnalyzer
 import com.socrata.soql.types.{SoQLType, SoQLValue}
 
-class QueryRewriterWithJoinEnabled(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) extends QueryRewriterImplementation(analyzer) {
+class QueryRewriterWithJoinEnabled(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) extends CompoundQueryRewriter(analyzer) {
   override def possibleRewrites(q: Analysis, rollups: Map[RollupName, Analysis]): Map[RollupName, Analysis] = {
     possibleRewrites(q, rollups, true)
   }
+
 }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewritingTestUtility.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/QueryRewritingTestUtility.scala
@@ -1,6 +1,6 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, CompoundQueryRewriter}
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, ColumnId, RollupName}
 import com.socrata.soql._
 import com.socrata.soql.ast.Select
@@ -39,7 +39,7 @@ object QueryRewritingTestUtility {
     val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
     val parserParams = AbstractParser.Parameters(allowJoins = true)
     val parser = new Parser(parserParams)
-    val rewriter: QueryRewriter = new QueryRewriterImplementation(analyzer)
+    val rewriter: CompoundQueryRewriter = new CompoundQueryRewriter(analyzer)
     AssertRewrite(
       parser.binaryTreeSelect,
       // aka Analyze(analyzer)
@@ -65,7 +65,7 @@ object QueryRewritingTestUtility {
     )
   }
 
-  def possiblyRewriteQuery(rewriter: QueryRewriter,analyzedQuery: SoQLAnalysis[String, SoQLType], rollups: Map[RollupName, Analysis]):
+  def possiblyRewriteQuery(rewriter: CompoundQueryRewriter, analyzedQuery: SoQLAnalysis[String, SoQLType], rollups: Map[RollupName, Analysis]):
   (SoQLAnalysis[String, SoQLType], Option[String]) = {
     val rewritten = rewriter.bestRollup(
       rewriter.possibleRewrites(analyzedQuery, rollups, false).toSeq)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterBase.scala
@@ -1,6 +1,6 @@
 package com.socrata.querycoordinator
 
-import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, BaseQueryRewriter}
 import com.socrata.querycoordinator.rollups.QueryRewriter.{Analysis, ColumnId, Expr, RollupName}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.SoQLAnalysis
@@ -116,7 +116,7 @@ abstract class TestQueryRewriterBase extends TestBase with TestCompoundQueryRewr
   /**
     * A handy function to test QueryRewriter.rewriteExpr
     */
-  def rewriteExpr(rewriter: QueryRewriterImplementation, e: Expr, q: Analysis, rollups: Map[RollupName, Analysis]): Map[RollupName, Option[Expr]] = {
+  def rewriteExpr(rewriter: BaseQueryRewriter, e: Expr, q: Analysis, rollups: Map[RollupName, Analysis]): Map[RollupName, Option[Expr]] = {
     rollups.mapValues { case r =>
       val rollupColIdx = r.selection.values.zipWithIndex.toMap
       rewriter.rewriteExpr(e, r, rollupColIdx)

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuserTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/fusion/CompoundTypeFuserTest.scala
@@ -2,7 +2,7 @@ package com.socrata.querycoordinator.fusion
 
 import com.socrata.querycoordinator.rollups.QueryRewriter._
 import com.socrata.querycoordinator.caching.SoQLAnalysisDepositioner
-import com.socrata.querycoordinator.rollups.{QueryRewriter, QueryRewriterImplementation}
+import com.socrata.querycoordinator.rollups.{QueryRewriter, CompoundQueryRewriter}
 import com.socrata.querycoordinator.{QueryParser, Schema, TestBase}
 import com.socrata.querycoordinator.util.Join
 import com.socrata.soql.ast.Select
@@ -21,7 +21,7 @@ class CompoundTypeFuserTest extends TestBase {
   import Join._
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter: QueryRewriter = new QueryRewriterImplementation(analyzer)
+  val rewriter: QueryRewriter = new CompoundQueryRewriter(analyzer)
 
   /** The raw of the table that we get as part of the secondary /schema call */
   val rawSchema = Map[String, SoQLType](

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/QueryRewriterTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/QueryRewriterTest.scala
@@ -1,0 +1,91 @@
+package com.socrata.querycoordinator.rollups
+
+import com.rojoma.json.v3.util.AutomaticJsonCodecBuilder
+import com.socrata.querycoordinator._
+import com.socrata.querycoordinator.rollups.QueryRewriter.ColumnId
+import com.socrata.soql._
+import com.socrata.soql.environment.TableName
+import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLFunctions, SoQLTypeInfo}
+import com.socrata.soql.parsing.{AbstractParser, Parser}
+import com.socrata.soql.types.{SoQLType, SoQLValue}
+
+
+class QueryRewriterTest extends BaseConfigurableRollupTest {
+
+  case class TestCase(query: String, rewrites: Map[String, String])
+
+  object TestCase {
+    implicit val jCodec = AutomaticJsonCodecBuilder[TestCase]
+  }
+
+  case class TestConfig(schemas: Map[String, SchemaConfig], rollups: Map[String, String], tests: Seq[TestCase])
+
+  object TestConfig {
+    implicit val jCodec = AutomaticJsonCodecBuilder[TestConfig]
+  }
+
+  //
+  // System Under Test
+  //
+  val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
+  val rewriter: QueryRewriter = new CompoundQueryRewriter(analyzer)
+
+  def fetchRollupInfo(config: TestConfig): Seq[RollupInfo] = config.rollups.map({
+    case (k, v) => RollupInfo(k, v)
+  }).toList
+
+  def getSchemaByTableName(tableName: TableName, config: TestConfig): SchemaWithFieldName = {
+    SchemaWithFieldName(
+      tableName.name,
+      config.schemas.getOrElse(tableName.name, Map.empty),
+      ":pk"
+    )
+  }
+
+  private def loadQueryAnalysis(q: String,
+                           context: AnalysisContext[SoQLType, SoQLValue],
+                           columnMapping: Map[QualifiedColumnName, String]):
+  BinaryTree[SoQLAnalysis[ColumnId, SoQLType]] = {
+
+    val parserParams = AbstractParser.Parameters(allowJoins = true)
+    val parsed = new Parser(parserParams).binaryTreeSelect(q)
+    val analyses = analyzer.analyzeBinary(parsed)(context)
+    val merged = SoQLAnalysis.merge(SoQLFunctions.And.monomorphic.get, analyses)
+    QueryParser.remapAnalyses(columnMapping, merged)
+  }
+
+  private def loadAndRunTests(configFile: String) {
+    val config = getConfig[TestConfig](configFile)
+    val context = getContext(config.schemas)
+    val mapping = getColumnMapping(config.schemas)
+    val schema = Schema(
+      "",
+      config.schemas.getOrElse("_", Map.empty).map({ case (k, v) => (v._2, v._1)}),
+      ":pk"
+    )
+
+    config.tests.foreach(test => {
+      val queryAnalysis = loadQueryAnalysis(test.query, context, mapping)
+
+      val rewrites = rewriter.possiblyRewriteOneAnalysisInQuery(
+        "_",
+        schema,
+        queryAnalysis,
+        None,
+        () => fetchRollupInfo(config),
+        (tableName) => getSchemaByTableName(tableName, config),
+        true
+      )
+
+      Console.println(rewrites)
+
+    })
+
+  }
+
+  test("rollup rewriter tests") {
+    loadAndRunTests("rollups/query_rewriter_test_configs/test_query_rewriter.json")
+  }
+
+
+}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/TestRollupQueryRewriter.scala
@@ -61,7 +61,7 @@ class TestRollupQueryRewriter extends BaseConfigurableRollupTest {
   // System Under Test
   //
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
-  val rewriter: QueryRewriter = new QueryRewriterWithJoinEnabled(analyzer)
+  val rewriter: QueryRewriterWithJoinEnabled = new QueryRewriterWithJoinEnabled(analyzer)
 
   //
   //  Helper methods


### PR DESCRIPTION
Moving ALL code related to the query rewriting to QueryRewriter class with intent to:

- enable testing of the QueryRewriter class as used in production
- clarify QueryRewriter derived classes hierarchy
- clearly define QueryRewriter interface
- encapsulate the implementation of the interface 