### PR TITLE
add field to query hit for rollups

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     val scalaTest = "3.0.8"
     val scalaCheck = "1.14.0"
     val simpleArm = "2.3.1"
-    val rollupMetrics = "3.3"
+    val rollupMetrics = "3.4"
   }
 
   val postgresql = "org.postgresql" % "postgresql" % versions.postgresql

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryExecutor.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryExecutor.scala
@@ -497,14 +497,14 @@ class QueryExecutor(httpClient: HttpClient,
                 resourceScope.close(result)
                 SchemaHashMismatch(newSchema)
               case Left(newStream) => try {
-                Metric.digest(QueryHit(dataset,analyses.toString,duration,LocalDateTime.now(ZoneOffset.UTC)))
+                Metric.digest(QueryHit(dataset,analyses.toString,rollupName,duration,LocalDateTime.now(ZoneOffset.UTC)))
                 forward(result, newStream)
               } finally {
                 newStream.close()
               }
             }
           case _ =>
-            Metric.digest(QueryHit(dataset,analyses.toString,duration,LocalDateTime.now(ZoneOffset.UTC)))
+            Metric.digest(QueryHit(dataset,analyses.toString,rollupName,duration,LocalDateTime.now(ZoneOffset.UTC)))
             forward(result, resourceScope.openUnmanaged(result.inputStream(), transitiveClose = List(result)))
         }
       }


### PR DESCRIPTION
Just adding a field to the metric.
We have the rollup name if one was used, lets put it in the metric also.