### PR TITLE
[EN-58991] Rollups that once fired no longer fire

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/BaseQueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/BaseQueryRewriter.scala
@@ -327,7 +327,7 @@ abstract class BaseQueryRewriter(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) {
     QueryParser.dsContext(columnIdMap, schema.schema)
   }
 
-  private[querycoordinator] def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
+  private[rollups] def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
                      getSchemaByTableName: TableName => SchemaWithFieldName): Map[RollupName, AnalysisTree] = {
 
     val dsContext = Map(TableName.PrimaryTable.qualifier -> prefixedDsContext(schema))

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/BaseQueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/BaseQueryRewriter.scala
@@ -327,7 +327,7 @@ abstract class BaseQueryRewriter(analyzer: SoQLAnalyzer[SoQLType, SoQLValue]) {
     QueryParser.dsContext(columnIdMap, schema.schema)
   }
 
-  private[rollups] def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
+  private[querycoordinator] def analyzeRollups(schema: Schema, rollups: Seq[RollupInfo],
                      getSchemaByTableName: TableName => SchemaWithFieldName): Map[RollupName, AnalysisTree] = {
 
     val dsContext = Map(TableName.PrimaryTable.qualifier -> prefixedDsContext(schema))

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/CompoundQueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/CompoundQueryRewriter.scala
@@ -9,7 +9,6 @@ import com.socrata.soql.typed.{ColumnRef, CompoundRollup, Indistinct}
 import com.socrata.soql.types.{SoQLType, SoQLValue}
 import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery, SoQLAnalyzer}
 import com.socrata.querycoordinator._
-import com.socrata.querycoordinator.util.BinaryTreeHelper
 
 
 /**

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -43,16 +43,18 @@ object QueryRewriter {
   }
 
   /**
-    * Merge rollups analysis
+    * Merge rollups analyses
     */
   def mergeRollupsAnalysis(rus: Map[RollupName, AnalysisTree]): Map[RollupName, Analysis] = {
-    rus.mapValues(bt =>
-      SoQLAnalysis.merge(
-        SoQLFunctions.And.monomorphic.get,
-        bt.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId))
-        )
-      ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
-    )
+    rus.mapValues(mergeAnalysis)
+  }
+
+  private[rollups] def mergeAnalysis(analysis: AnalysisTree): Analysis = {
+    SoQLAnalysis.merge(
+      SoQLFunctions.And.monomorphic.get,
+      analysis.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId))
+      )
+    ).outputSchema.leaf.mapColumnIds((columnName, _) => columnName.name)
   }
 
   def primaryRollup(names: Seq[String]): Option[String] = {

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/rollups/QueryRewriter.scala
@@ -49,7 +49,7 @@ object QueryRewriter {
     rus.mapValues(mergeAnalysis)
   }
 
-  private[rollups] def mergeAnalysis(analysis: AnalysisTree): Analysis = {
+  private[querycoordinator] def mergeAnalysis(analysis: AnalysisTree): Analysis = {
     SoQLAnalysis.merge(
       SoQLFunctions.And.monomorphic.get,
       analysis.map(a => a.mapColumnIds((columnId, _) => ColumnName(columnId))

--- a/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_1.json
+++ b/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_1.json
@@ -1,0 +1,20 @@
+{
+  "schemas": {
+    "_": {
+      "a115-2115": ["number", "incident_id"],
+      "a116-2116": ["text", "incident"],
+      "a117-2117": ["number", "case_id"],
+      "a118-2118": ["text", "case_status"],
+      "a119-2119": ["text", "case_description"],
+      "a120-2120": ["date", "case_date"],
+      "a121-2121": ["point", "location"],
+      "a122-2122": ["date", "incident_date"]
+    }
+  },
+  "rollups": {
+    "p1": "SELECT `_a115-2115` AS `incident_id`, `_a116-2116` AS `incident` WHERE `_a118-2118` = 'Open' |> SELECT `incident_id`, `incident` WHERE (contains(lower(`incident`), 'robbery')) |> SELECT `incident_id` GROUP BY `incident_id`"
+  },
+  "tests": {
+    "p1": "SELECT "
+  }
+}

--- a/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_1.json
+++ b/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_1.json
@@ -11,10 +11,10 @@
       "a122-2122": ["date", "incident_date"]
     }
   },
-  "rollups": {
+  "pipes": {
     "p1": "SELECT `_a115-2115` AS `incident_id`, `_a116-2116` AS `incident` WHERE `_a118-2118` = 'Open' |> SELECT `incident_id`, `incident` WHERE (contains(lower(`incident`), 'robbery')) |> SELECT `incident_id` GROUP BY `incident_id`"
   },
-  "tests": {
-    "p1": "SELECT "
+  "merges": {
+    "p1": "SELECT ListMap(incident_id -> a115-2115 :: number) WHERE op$and(op$=(a118-2118 :: text,\"Open\" :: text) :: boolean,contains(lower(a116-2116 :: text) :: text,\"robbery\" :: text) :: boolean) :: boolean GROUP BY a115-2115 :: number"
   }
 }

--- a/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_2.json
+++ b/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_2.json
@@ -1,0 +1,18 @@
+{
+  "schemas": {
+    "_": {
+      "dxyz-num1": ["number", "number1"],
+      "wido-ward": ["number", "ward"],
+      "crim-typ3": ["text", "crime_type"],
+      "dont-roll": ["text", "dont_create_rollups"],
+      "crim-date": ["floating_timestamp", "crime_date"],
+      "some-date": ["floating_timestamp", "some_date"]
+    }
+  },
+  "pipes": {
+    "p1": "SELECT `_wido-ward` as ward, `_crim-typ3` as crime_type, `_dxyz-num1` as number1 WHERE number1='0' |> SELECT ward, crime_type WHERE crime_type='traffic'"
+  },
+  "merges": {
+    "p1": "SELECT ListMap(ward -> wido-ward :: number, crime_type -> crim-typ3 :: text) WHERE op$and(op$=(dxyz-num1 :: number,cast$number(\"0\" :: text) :: number) :: boolean,op$=(crim-typ3 :: text,\"traffic\" :: text) :: boolean) :: boolean"
+  }
+}

--- a/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_3.json
+++ b/query-coordinator/src/test/resources/rollups/analysis_merge_test_configs/test_pipes_3.json
@@ -1,0 +1,52 @@
+{
+  "schemas": {
+    "_": {
+      "a169-1263": ["number", "unique_id"],
+      "a180-1274": ["floating_timestamp", "last_change"],
+      "a165-1259": ["text", "jur"],
+      "a176-1270": ["text", "parid"],
+      "a159-1253": ["number", "taxyr"],
+      "a157-1251": ["text", "nbhd"],
+      "a168-1262": ["text", "nbhd_desc"],
+      "a154-1248": ["number", "subkey"],
+      "a171-1265": ["text", "heartyp"],
+      "a173-1267": ["text", "own1"],
+      "a178-1272": ["text", "addr1"],
+      "a160-1254": ["text", "addr3"],
+      "a177-1271": ["floating_timestamp", "application_date"],
+      "a164-1258": ["text", "hearing_date"],
+      "a166-1260": ["number", "county_value"],
+      "a167-1261": ["text", "taxpayer_opinion_value"],
+      "a162-1256": ["text", "total_under_dispute"],
+      "a183-1277": ["text", "agent"],
+      "a161-1255": ["text", "attorney"],
+      "a172-1266": ["text", "case_status_code"],
+      "a158-1252": ["text", "case_status"],
+      "a184-1278": ["text", "reason_for_appeal_code"],
+      "a179-1273": ["text", "reason_for_appeal"],
+      "a175-1269": ["floating_timestamp", "decision_date"],
+      "a156-1250": ["text", "noticedate"],
+      "a174-1268": ["text", "decision_value"],
+      "a155-1249": ["number", "luc"],
+      "a185-1279": ["text", "class"],
+      "a153-1247": ["text", "class_desc"],
+      "a181-1275": ["text", "xcoord"],
+      "a170-1264": ["text", "ycoord"],
+      "a163-1257": ["text", "location"],
+      "a182-1276": ["text", "gispin"]
+    },
+    "_7ecp-3dim": {
+      "b100-b100": ["text", "loc_id"],
+      "b101-b101": ["point", "centroid"]
+    }
+  },
+  "pipes": {
+    "p1": "SELECT `_a169-1263` AS `unique_id`, `_a180-1274` AS `last_change`, `_a165-1259` AS `jur`, `_a176-1270` AS `parid`, `_a159-1253` AS `taxyr`, `_a157-1251` AS `nbhd`, `_a168-1262` AS `nbhd_desc`, `_a154-1248` AS `subkey`, `_a171-1265` AS `heartyp`, `_a173-1267` AS `own1`, `_a178-1272` AS `addr1`, `_a160-1254` AS `addr3`, `_a177-1271` AS `application_date`, `_a164-1258` AS `hearing_date`, `_a166-1260` AS `county_value`, `_a167-1261` AS `taxpayer_opinion_value`, `_a162-1256` AS `total_under_dispute`, `_a183-1277` AS `agent`, `_a161-1255` AS `attorney`, `_a172-1266` AS `case_status_code`, `_a158-1252` AS `case_status`, `_a184-1278` AS `reason_for_appeal_code`, `_a179-1273` AS `reason_for_appeal`, `_a175-1269` AS `decision_date`, `_a156-1250` AS `noticedate`, `_a174-1268` AS `decision_value`, `_a155-1249` AS `luc`, `_a185-1279` AS `class`, `_a153-1247` AS `class_desc`, `_a181-1275` AS `xcoord`, `_a170-1264` AS `ycoord`, `_a163-1257` AS `location`, `_a182-1276` AS `gispin` |> SELECT `unique_id`, `last_change`, `jur`, `parid`, `taxyr`, `nbhd`, `nbhd_desc`, `subkey`, `heartyp`, `own1`, `addr1`, `addr3`, `application_date`, `hearing_date`, `county_value`, `taxpayer_opinion_value`, `total_under_dispute`, `agent`, `attorney`, `case_status_code`, `case_status`, `reason_for_appeal_code`, `reason_for_appeal`, `decision_date`, `noticedate`, `decision_value`, `luc`, `class`, `class_desc`, `xcoord`, `ycoord`, `location`, `gispin` |> SELECT `unique_id`, `last_change`, `jur`, `parid`, `taxyr`, `nbhd`, `nbhd_desc`, `subkey`, `heartyp`, `own1`, `addr1`, `addr3`, `application_date`, `hearing_date`, `county_value`, `taxpayer_opinion_value`, `total_under_dispute`, `agent`, `attorney`, `case_status_code`, `case_status`, `reason_for_appeal_code`, `reason_for_appeal`, `decision_date`, `noticedate`, `decision_value`, `luc`, `class`, `class_desc`, `xcoord`, `ycoord`, `location`, `gispin`, @s0.`centroid` LEFT OUTER JOIN (SELECT `_b100-b100` AS `loc_id`, `_b101-b101` AS `centroid` FROM @7ecp-3dim |> SELECT `loc_id`, `centroid`) AS @s0 ON @s0.`loc_id` = `gispin`"
+  },
+  "merges": {
+    "p1": "SELECT ListMap(unique_id -> a169-1263 :: number, last_change -> a180-1274 :: floating_timestamp, jur -> a165-1259 :: text, parid -> a176-1270 :: text, taxyr -> a159-1253 :: number, nbhd -> a157-1251 :: text, nbhd_desc -> a168-1262 :: text, subkey -> a154-1248 :: number, heartyp -> a171-1265 :: text, own1 -> a173-1267 :: text, addr1 -> a178-1272 :: text, addr3 -> a160-1254 :: text, application_date -> a177-1271 :: floating_timestamp, hearing_date -> a164-1258 :: text, county_value -> a166-1260 :: number, taxpayer_opinion_value -> a167-1261 :: text, total_under_dispute -> a162-1256 :: text, agent -> a183-1277 :: text, attorney -> a161-1255 :: text, case_status_code -> a172-1266 :: text, case_status -> a158-1252 :: text, reason_for_appeal_code -> a184-1278 :: text, reason_for_appeal -> a179-1273 :: text, decision_date -> a175-1269 :: floating_timestamp, noticedate -> a156-1250 :: text, decision_value -> a174-1268 :: text, luc -> a155-1249 :: number, class -> a185-1279 :: text, class_desc -> a153-1247 :: text, xcoord -> a181-1275 :: text, ycoord -> a170-1264 :: text, location -> a163-1257 :: text, gispin -> a182-1276 :: text, centroid -> _s0.centroid :: point) LEFT OUTER JOIN (SELECT ListMap(loc_id -> b100-b100 :: text, centroid -> b101-b101 :: point) FROM @7ecp-3dim) AS @s0 ON op$=(_s0.loc_id :: text,a182-1276 :: text) :: boolean"
+  }
+}
+
+
+

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
@@ -1,5 +1,100 @@
 package com.socrata.querycoordinator.rollups
 
-class MergeAnalysisTest {
+import com.rojoma.json.v3.util.AutomaticJsonCodecBuilder
+import com.socrata.querycoordinator._
+import com.socrata.querycoordinator.rollups.QueryRewriter.{AnalysisTree, RollupName}
+import com.socrata.soql._
+import com.socrata.soql.environment.{TableName}
+import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
+
+/**
+  *  How to use MergeAnalysisTest:
+  *
+  *
+  *  1. Create new test case in resources/rollups/analysis_merge_test_configs
+  *     Test case json file format:
+  *     {
+  *       "schemas": {
+  *         "_": {                                   <- root schema
+  *           "2dup-k82r": ["number", "rowkey"]      <- column fxf, column type and column name
+  *         },
+  *         "ep9t-zk9z": {
+  *           "47rk-qiqd": ["text", "county"]
+  *         }
+  *       },
+  *       "rollups": {                                <- rollup as stored in pg_secondary rollup_map
+  *         "r1": "SELECT `_93hn-8t73` AS `casenumber`, max(`_u4tu-5655`) AS `submitted_` GROUP BY `casenumber`"
+  *       },
+  *       "tests": {                                  <- merges for the rollup definitions
+  *         "r1": "SELECT "
+  *       }
+  *     }
+  *  2. Get the column names, fxf and types from the pg_secondary rollup_map and column_map
+  *       (filter column map by dataset id)
+  *  3. Keep test case files once done debugging.
+  */
+
+class MergeAnalysisTest extends BaseConfigurableRollupTest {
+
+  case class TestConfig(schemas: Map[String, SchemaConfig], pipes: Map[String, String], merges: Map[String, String])
+
+  object TestConfig {
+    implicit val jCodec = AutomaticJsonCodecBuilder[TestConfig]
+  }
+
+  //
+  // System Under Test
+  //
+  val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
+  val rewriter: BaseQueryRewriter = new CompoundQueryRewriter(analyzer)
+
+  //
+  //  Fetchers for QueryRewriter
+  //
+  def fetchRollupInfo(config: TestConfig): Seq[RollupInfo] = config.pipes.map({
+    case (k, v) => RollupInfo(k, v)
+  }).toList
+
+  def getSchemaByTableName(tableName: TableName, config: TestConfig): SchemaWithFieldName = {
+    SchemaWithFieldName(
+      tableName.name,
+      config.schemas.getOrElse(tableName.name, Map.empty),
+      ":pk"
+    )
+  }
+
+  //
+  //  Generic method to load and run test
+  //
+  private def loadAndRunTests(configFile: String) {
+    val config = getConfig[TestConfig](configFile)
+    val schema = Schema(
+      "",
+      config.schemas.getOrElse("_", Map.empty).map({ case (k, v) => (k, v._1)}),
+      ":pk"
+    )
+
+    val rollupFetcher = () => fetchRollupInfo(config)
+    val schemaFetcher = (tableName) => getSchemaByTableName(tableName, config)
+
+    val rollups: Map[RollupName, AnalysisTree] = rollupFetcher() match {
+      case Seq() => Map.empty
+      case rollups => rewriter.analyzeRollups(schema, rollups, schemaFetcher)
+    }
+
+    rollups.foreach({ case (name, analysis) =>
+      val merged = QueryRewriter.mergeAnalysis(analysis)
+      merged.toString should equal(config.merges(name))
+    })
+
+  }
+
+  //
+  //  Actual test
+  //
+  test("pipes merge tests") {
+    loadAndRunTests("rollups/analysis_merge_test_configs/test_pipes_1.json")
+    loadAndRunTests("rollups/analysis_merge_test_configs/test_pipes_2.json")
+  }
 
 }

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
@@ -1,0 +1,5 @@
+package com.socrata.querycoordinator.rollups
+
+class MergeAnalysisTest {
+
+}

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/rollups/MergeAnalysisTest.scala
@@ -82,6 +82,8 @@ class MergeAnalysisTest extends BaseConfigurableRollupTest {
       case rollups => rewriter.analyzeRollups(schema, rollups, schemaFetcher)
     }
 
+    rollups.size should equal(config.merges.size)
+
     rollups.foreach({ case (name, analysis) =>
       val merged = QueryRewriter.mergeAnalysis(analysis)
       merged.toString should equal(config.merges(name))
@@ -95,6 +97,7 @@ class MergeAnalysisTest extends BaseConfigurableRollupTest {
   test("pipes merge tests") {
     loadAndRunTests("rollups/analysis_merge_test_configs/test_pipes_1.json")
     loadAndRunTests("rollups/analysis_merge_test_configs/test_pipes_2.json")
+    loadAndRunTests("rollups/analysis_merge_test_configs/test_pipes_3.json")
   }
 
 }


### PR DESCRIPTION
The suspicion is that piped queries and rollups rewrites does not work the way they should. Adding tests for pipes merge to explicitly clarify the outcomes of the piped queries merges.