### PR TITLE
EN-60548: Fake-locations on the new query path

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "4.12.12"
+    val soqlStdlib = "4.12.13"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"


### PR DESCRIPTION
Plumb location subcolumn info down to the secondary, after changing it from its JSON-friendly sequence-of-pairs form to a more sensible map form