### PR TITLE
Update simple-arm

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val slf4j =  "1.7.7"
     val scalaTest = "3.0.8"
     val scalaCheck = "1.14.0"
-    val simpleArm = "2.3.1"
+    val simpleArm = "2.3.3"
     val rollupMetrics = "3.5"
   }
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/Main.scala
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory
 final abstract class Main
 
 object Main extends App with DynamicPortMap {
-
   def withDefaultAddress(config: Config): Config = {
     val ifaces = ServiceInstanceBuilder.getAllLocalIPs
     if (ifaces.isEmpty) {
@@ -56,6 +55,14 @@ object Main extends App with DynamicPortMap {
 
   PropertyConfigurator.configure(Propertizer("log4j", config.log4j))
   val log = org.slf4j.LoggerFactory.getLogger(classOf[Main])
+
+  ResourceScope.onLeak { rs =>
+    try {
+      log.warn("Resource scope {} leaked!", rs.name)
+    } finally {
+      rs.close()
+    }
+  }
 
   val analyzer = new SoQLAnalyzer(SoQLTypeInfo, SoQLFunctionInfo)
   def typeSerializer(typ: SoQLType): String = typ.name.name

--- a/query-coordinator/src/test/scala/com/socrata/querycoordinator/util/TeeToTempInputStreamTest.scala
+++ b/query-coordinator/src/test/scala/com/socrata/querycoordinator/util/TeeToTempInputStreamTest.scala
@@ -2,7 +2,7 @@ package com.socrata.querycoordinator.util
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
-import com.rojoma.simplearm.util._
+import com.rojoma.simplearm.v2._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{FunSuite, MustMatchers}
 


### PR DESCRIPTION
* Remove a single remaining simple-arm-v1ism (not sure why s-a 1 isn't on the classpath anymore?  Maybe a change to POM generation in newer SBTs)
* Log (and close) resource scopes that are leaked and discovered by the garbage collector