### PR TITLE
EN-61797: use release name as git tag and deploy tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     label params.AGENT
   }
   environment {
-    SERVICE = service
+    SERVICE = "${service}"
   }
   stages {
     stage('Release Tag') {


### PR DESCRIPTION
## Before

We use the sbt version incremented using sbt release for git tags for releases.
For deploy tags, we use the format `${env.SERVICE_VERSION}_${env.BUILD_ID}_${env.SERVICE_SHA}`.  This is for release builds as well as staging builds.

## After

We use the release name for both the git tag and deploy tag for releases.  
For staging builds, we use the existing format with `SERVICE_VERSION = 'STAGING'`.