### PR TITLE
Simplify assembly filename

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ pipeline {
         script {
           sbtbuild.setScalaVersion("2.12")
           sbtbuild.setSubprojectName("queryCoordinator")
+          sbtbuild.setSrcJar("query-coordinator/target/query-coordinator-assembly.jar")
           echo "Building sbt project..."
           sbtbuild.build()
         }

--- a/query-coordinator/build.sbt
+++ b/query-coordinator/build.sbt
@@ -51,3 +51,7 @@ buildInfoPackage := "com.socrata.querycoordinator"
 buildInfoOptions += BuildInfoOption.ToMap
 
 assembly/test := {}
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value


### PR DESCRIPTION
* The filename no longer contains the version number
* The file is stored in target instead of target/scala-$version