### PR TITLE
EN-63625: QueryParser respects passed in limit on UNIONs

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/QueryParser.scala
@@ -75,20 +75,13 @@ class QueryParser(analyzer: SoQLAnalyzer[SoQLType, SoQLValue], schemaFetcher: Sc
 
   private def limitRows(analyses: BinaryTree[SoQLAnalysis[ColumnName, SoQLType]])
     : Either[Result, BinaryTree[SoQLAnalysis[ColumnName, SoQLType]]] = {
-    val last = analyses.outputSchema.leaf
+    val last: SoQLAnalysis[ColumnName, SoQLType] = BinaryTreeHelper.outerMostAnalyses(analyses).last
     last.limit match {
       case Some(lim) =>
         val actualMax = BigInt(maxRows.map(_.toLong).getOrElse(Long.MaxValue))
         if (lim <= actualMax) { Right(analyses) }
         else { Left(RowLimitExceeded(actualMax)) }
       case None =>
-        val outermostAnalyses: Seq[SoQLAnalysis[ColumnName, SoQLType]] = BinaryTreeHelper.outerMostAnalyses(analyses)
-        val last: SoQLAnalysis[ColumnName, SoQLType] = outermostAnalyses match {
-          case Seq(one) =>
-            one
-          case moreThanOne: Seq[_] =>
-            moreThanOne.last
-        }
         val lastWithLimit = last.copy(limit = Some(defaultRowsLimit))
         Right(BinaryTreeHelper.replace(analyses, last, lastWithLimit))
     }


### PR DESCRIPTION
QueryParser's limitRows function would always check for a limit on the leftmost leaf, which ran counter to Core's policy of setting the its "default" maxInt limit on the rightmost/last leaf . Because of this, QC would not see the existing default limit and would override it with its own default limit of 1000 rows. 

Fixed by changing the limitRows function to correctly look at the rightmost/last leaf when checking for an existing limit.