### PR TITLE
EN-65713: move release tagging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,13 +16,16 @@ def releaseTag = new com.socrata.ReleaseTag(steps, service)
 pipeline {
   options {
     ansiColor('xterm')
+    buildDiscarder(logRotator(numToKeepStr: '50'))
+    disableConcurrentBuilds(abortPrevious: true)
+    timeout(time: 20, unit: 'MINUTES')
   }
   parameters {
-    booleanParam(name: 'RELEASE_BUILD', defaultValue: false, description: 'Are we building a release candidate?')
-    booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: false, description: 'To test out the release build without creating a new tag.')
-    string(name: 'RELEASE_NAME', defaultValue: '', description: 'For release builds, the release name which is used for the git tag and the deploy tag.')
     string(name: 'AGENT', defaultValue: 'build-worker', description: 'Which build agent to use?')
     string(name: 'BRANCH_SPECIFIER', defaultValue: 'origin/main', description: 'Use this branch for building the artifact.')
+    booleanParam(name: 'RELEASE_BUILD', defaultValue: false, description: 'Are we building a release candidate?')
+    booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: false, description: 'To test out the release build without creating a new tag.')
+    string(name: 'RELEASE_NAME', description: 'For release builds, the release name which is used for the git tag and the deploy tag.')
   }
   agent {
     label params.AGENT
@@ -31,22 +34,6 @@ pipeline {
     WEBHOOK_ID = 'WEBHOOK_IQ'
   }
   stages {
-    stage('Release Tag') {
-      when {
-        expression { return params.RELEASE_BUILD }
-      }
-      steps {
-        script {
-          lastStage = env.STAGE_NAME
-          if (params.RELEASE_DRY_RUN) {
-            echo 'DRY RUN: Skipping release tag creation'
-          }
-          else {
-            env.GIT_TAG = releaseTag.create(params.RELEASE_NAME)
-          }
-        }
-      }
-    }
     stage('Build') {
       steps {
         script {
@@ -54,12 +41,11 @@ pipeline {
           sbtbuild.setScalaVersion("2.12")
           sbtbuild.setSubprojectName("queryCoordinator")
           sbtbuild.setSrcJar("query-coordinator/target/query-coordinator-assembly.jar")
-          echo "Building sbt project..."
           sbtbuild.build()
         }
       }
     }
-    stage('Dockerize') {
+    stage('Docker Build') {
       when {
         not { expression { isPr } }
       }
@@ -67,28 +53,75 @@ pipeline {
         script {
           lastStage = env.STAGE_NAME
           if (params.RELEASE_BUILD) {
-            env.REGISTRY_PUSH = (params.RELEASE_DRY_RUN) ? 'none' : 'all'
-            env.DOCKER_TAG = dockerize.docker_build_specify_tag_and_push(params.RELEASE_NAME, sbtbuild.getDockerPath(), sbtbuild.getDockerArtifact(), env.REGISTRY_PUSH)
+            env.DOCKER_TAG = dockerize.dockerBuildWithSpecificTag(
+              tag: params.RELEASE_NAME,
+              path: sbtbuild.getDockerPath(),
+              artifacts: [sbtbuild.getDockerArtifact()]
+            )
           } else {
-            env.REGISTRY_PUSH = 'internal'
-            env.DOCKER_TAG = dockerize.docker_build('STAGING', env.GIT_COMMIT, sbtbuild.getDockerPath(), sbtbuild.getDockerArtifact(), env.REGISTRY_PUSH)
+            env.DOCKER_TAG = dockerize.dockerBuildWithDefaultTag(
+              version: 'STAGING',
+              sha: env.GIT_COMMIT,
+              path: sbtbuild.getDockerPath(),
+              artifacts: [sbtbuild.getDockerArtifact()]
+            )
           }
-          currentBuild.description = env.DOCKER_TAG
         }
       }
       post {
         success {
           script {
-            if (params.RELEASE_BUILD && !params.RELEASE_DRY_RUN){
+            if (params.RELEASE_BUILD) {
+              env.GIT_TAG = releaseTag.getFormattedTag(params.RELEASE_NAME)
+              if (releaseTag.doesReleaseTagExist(params.RELEASE_NAME)) {
+                echo "REBUILD: Tag ${env.GIT_TAG} already exists"
+                return
+              }
+              if (params.RELEASE_DRY_RUN) {
+                echo "DRY RUN: Would have created ${env.GIT_TAG} and pushed it to the repo"
+                currentBuild.description = "${service}:${params.RELEASE_NAME} - DRY RUN"
+                return
+              }
+              releaseTag.create(params.RELEASE_NAME)
+            }
+          }
+        }
+      }
+    }
+    stage('Publish') {
+      when {
+        allOf {
+          not { expression { isPr } }
+          not { expression { return params.RELEASE_BUILD && params.RELEASE_DRY_RUN } }
+        }
+      }
+      steps {
+        script {
+          lastStage = env.STAGE_NAME
+          if (params.RELEASE_BUILD) {
+            env.BUILD_ID = dockerize.publish(sourceTag: env.DOCKER_TAG)
+          } else {
+            env.BUILD_ID = dockerize.publish(
+              sourceTag: env.DOCKER_TAG,
+              environments: ['internal']
+            )
+          }
+          currentBuild.description = env.BUILD_ID
+        }
+      }
+      post {
+        success {
+          script {
+            if (params.RELEASE_BUILD){
               Map buildInfo = [
                 "project_id": service,
-                "build_id": env.DOCKER_TAG,
+                "build_id": env.BUILD_ID,
                 "release_id": params.RELEASE_NAME,
                 "git_tag": env.GIT_TAG,
               ]
               createBuild(
                 buildInfo,
-                rmsSupportedEnvironment.production
+                rmsSupportedEnvironment.staging //production
               )
             }
           }
@@ -103,8 +136,11 @@ pipeline {
       steps {
         script {
           lastStage = env.STAGE_NAME
-          // uses env.DOCKER_TAG and deploys to staging by default
-          marathonDeploy(serviceName: service)
+          marathonDeploy(
+            serviceName: service,
+            tag: env.BUILD_ID,
+            enviroment: 'staging'
+          )
         }
       }
     }
@@ -112,8 +148,11 @@ pipeline {
   post {
     failure {
       script {
-        if (!isPr) {
-          teamsMessage(message: "Build [${currentBuild.fullDisplayName}](${env.BUILD_URL}) has failed in stage ${lastStage}", webhookCredentialID: WEBHOOK_ID)
+        if (env.JOB_NAME.contains("${service}/main")) {
+          teamsMessage(
+            message: "Build [${currentBuild.fullDisplayName}](${env.BUILD_URL}) has failed in stage ${lastStage}",
+            webhookCredentialID: WEBHOOK_ID
+          )
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
               ]
               createBuild(
                 buildInfo,
-                rmsSupportedEnvironment.staging //production
+                rmsSupportedEnvironment.production
               )
             }
           }


### PR DESCRIPTION
This commit moves the release tagging after a successful docker build. In order to do this, it separates the docker build from the publishing of the images into separate Jenkinsfile steps.