### PR TITLE
EN-66372: specify build-worker-pg13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     timeout(time: 20, unit: 'MINUTES')
   }
   parameters {
-    string(name: 'AGENT', defaultValue: 'build-worker', description: 'Which build agent to use?')
+    string(name: 'AGENT', defaultValue: 'build-worker-pg13', description: 'Which build agent to use?')
     string(name: 'BRANCH_SPECIFIER', defaultValue: 'origin/main', description: 'Use this branch for building the artifact.')
     booleanParam(name: 'RELEASE_BUILD', defaultValue: false, description: 'Are we building a release candidate?')
     booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: false, description: 'To test out the release build without creating a new tag.')


### PR DESCRIPTION
We want to split the build workers into ones that have postgres and ones that don’t. In order to do this, we need to make sure that the jobs that need the build worker with postgres use agent “build-worker-pg13” and the jobs that don’t use agent “build-worker”. This commit specifies that this job needs to run on agent “build-worker-pg13”.