### PR TITLE
EN-67069: Better(?) secondary-selection on the v3 path

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdpartyUtils = "5.0.0"
     val socrataUtils = "0.11.0"
-    val soqlStdlib = "4.14.54"
+    val soqlStdlib = "4.14.55"
     val protobuf = "2.4.1"
     val trove4j = "3.0.3"
     val sprayCaching = "1.2.2"

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/Secondary.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/Secondary.scala
@@ -31,6 +31,10 @@ class Secondary(secondaryProvider: ServiceProviderProvider[AuxiliaryData],
     secondaryInstance.arbitraryInstance()
   }
 
+  def allSecondaries(): Seq[String] = {
+    secondaryInstance.allInstances()
+  }
+
   def unassociatedServiceInstance(instanceName: String): Option[ServiceInstance[AuxiliaryData]] =
     Option(secondaryProvider.provider(instanceName).getInstance())
 

--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/NewQueryError.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/util/NewQueryError.scala
@@ -1,0 +1,108 @@
+package com.socrata.querycoordinator.util
+
+import scala.util.parsing.input.NoPosition
+
+import com.rojoma.json.v3.codec.{JsonDecode, JsonEncode, DecodeError}
+import com.rojoma.json.v3.util.AutomaticJsonCodec
+import com.socrata.soql.environment.{Source, ScopedResourceName}
+import com.socrata.soql.util.{EncodedError, SoQLErrorCodec, SoQLErrorDecode, SoQLErrorEncode}
+
+import com.socrata.querycoordinator.resources.NewQueryResource.{DatasetInternalName, Stage}
+
+sealed abstract class NewQueryError[+RNS]
+
+object NewQueryError {
+  sealed abstract class SecondarySelectionError[+RNS] extends NewQueryError[RNS]
+
+  object SecondarySelectionError {
+    private def stringifyDS[RNS](name: ScopedResourceName[RNS]): String =
+      s"${name.name.name}"
+
+    case class NoSecondariesForDataset[+RNS](name: ScopedResourceName[RNS])
+        extends SecondarySelectionError[RNS]
+
+    object NoSecondariesForDataset {
+      private val tag = "soql.query-coordinator.no-secondaries-for-dataset"
+
+      @AutomaticJsonCodec
+      case class Fields()
+
+      implicit def encode[RNS: JsonEncode] =
+        new SoQLErrorEncode[NoSecondariesForDataset[RNS]] {
+          override val code = tag
+
+          def encode(err: NoSecondariesForDataset[RNS]) =
+            result(
+              Fields(),
+              s"No secondaries available for dataset ${stringifyDS(err.name)}",
+              Source.Saved(err.name, NoPosition)
+            )
+        }
+
+      implicit def decode[RNS: JsonDecode] =
+        new SoQLErrorDecode[NoSecondariesForDataset[RNS]] {
+          override val code = tag
+
+          def decode(v: EncodedError) =
+            for {
+              _ <- data[Fields](v)
+              source <- source[RNS](v)
+              srn <- source.scopedResourceName match {
+                case Some(srn) => Right(srn)
+                case None => Left(DecodeError.InvalidValue(JsonEncode.toJValue(v.source.get))) // we know there's _a_ source because we just got it
+              }
+            } yield {
+              NoSecondariesForDataset(srn)
+            }
+        }
+    }
+
+    case class NoSecondariesForAllDatasets()
+        extends SecondarySelectionError[Nothing]
+
+
+    object NoSecondariesForAllDatasets {
+      private val tag = "soql.query-coordinator.no-secondaries-for-all-datasets"
+
+      @AutomaticJsonCodec
+      case class Fields()
+
+      implicit def encode[RNS: JsonEncode] =
+        new SoQLErrorEncode[NoSecondariesForAllDatasets] {
+          override val code = tag
+
+          def encode(err: NoSecondariesForAllDatasets) =
+            result(
+              Fields(),
+              s"No secondaries in common for all datasets.  Perhaps they need to be collocated."
+            )
+        }
+
+      implicit def decode =
+        new SoQLErrorDecode[NoSecondariesForAllDatasets] {
+          override val code = tag
+
+          def decode(v: EncodedError) =
+            for {
+              _ <- data[Fields](v)
+            } yield {
+              NoSecondariesForAllDatasets()
+            }
+        }
+    }
+
+    def errorCodecs[RNS: JsonEncode: JsonDecode, T >: SecondarySelectionError[RNS] <: AnyRef](
+      codecs: SoQLErrorCodec.ErrorCodecs[T] = new SoQLErrorCodec.ErrorCodecs[T]
+    ) = {
+      codecs
+        .branch[NoSecondariesForDataset[RNS]]
+        .branch[NoSecondariesForAllDatasets]
+    }
+  }
+
+  def errorCodecs[RNS: JsonEncode: JsonDecode, T >: NewQueryError[RNS] <: AnyRef](
+    codecs: SoQLErrorCodec.ErrorCodecs[T] = new SoQLErrorCodec.ErrorCodecs[T]
+  ) = {
+    SecondarySelectionError.errorCodecs[RNS, T](codecs)
+  }
+}

--- a/secondary-selector/src/main/scala/com/socrata/querycoordinator/SecondaryInstanceSelector.scala
+++ b/secondary-selector/src/main/scala/com/socrata/querycoordinator/SecondaryInstanceSelector.scala
@@ -109,6 +109,8 @@ class SecondaryInstanceSelector(config: SecondarySelectorConfig) extends Metrics
 
   def arbitraryInstance(): String = allServers(Random.nextInt(allServers.length)).name
 
+  def allInstances(): Seq[String] = allServers.map(_.name)
+
   def getInstanceName(dataset: String, isInSecondary: (String => Option[Boolean]), excludedSecondaryNames: Set[String]): Option[String] = {
     // datasetMap is a synchronized map, then  lock on dss for any access inside dss
     val dss = Await.result(datasetMap(dataset)(new DatasetServers), waitTime)


### PR DESCRIPTION
Now we find all secondaries for all datasets involved in a query, intersect those sets together, and pick one at random from that intersection.

Also if we can't find a satisfactory secondary, return a real soql error.