### PR TITLE
EN-71533: pin pipelines library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
-@Library('socrata-pipeline-library')
+@Library('socrata-pipeline-library@0.2.0') _
 
-Map pipelineParams = [
+commonServicePipeline(
   defaultBuildWorker: 'build-worker-pg13',
   deploymentEcosystem: 'marathon-mesos',
   language: 'scala',
@@ -11,6 +11,4 @@ Map pipelineParams = [
   teamsChannelWebhookId: 'WORKFLOW_IQ',
   scalaSrcJar: 'query-coordinator/target/query-coordinator-assembly.jar',
   scalaSubprojectName: 'queryCoordinator',
-]
-
-commonServicePipeline(pipelineParams)
+)


### PR DESCRIPTION
This commit pins the version for socrata-pipeline-library so that it will not break when breaking changes are added in subsequent versions.