### PR TITLE
ECSify

### DIFF
--- a/query-coordinator/docker/Dockerfile
+++ b/query-coordinator/docker/Dockerfile
@@ -5,6 +5,8 @@ EXPOSE 6031/udp
 ENV JMX_PORT 6039
 # EXPOSE 6039
 
+RUN apt-get -y update && apt-get -y install jq
+
 ENV SERVER_ROOT /srv/query-coordinator/
 # TODO sbt task to copy latest jar into docker/
 ENV SERVER_ARTIFACT query-coordinator-assembly.jar

--- a/query-coordinator/docker/ship.d/run
+++ b/query-coordinator/docker/ship.d/run
@@ -1,10 +1,17 @@
-#!/bin/sh
+#!/bin/bash
+
 set -ev
+set -o pipefail
 
 CREDSFILE=/dev/shm/query-coordinator-cache-creds
 
 if [ -e $CREDSFILE ]; then
     . $CREDSFILE
+fi
+
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+    ARK_HOST="$(curl -sf "$ECS_CONTAINER_METADATA_URI_V4" | jq -r '.Networks[0].IPv4Addresses[0]')"
+    export ARK_HOST
 fi
 
 if [ -d /mnt/mesos/sandbox ]; then
@@ -16,7 +23,7 @@ else
     export HEAPDUMP=""
 fi
 
-if [ -z "$MARATHON_APP_ID" ]; then
+if [ -z "$MARATHON_APP_ID" ] && [ -z "$ECS_CONTAINER_METADATA_URI_V4" ] ; then
     echo "Not running in marathon, so I will not compile the config template file!"
     echo "If you want to force config template compilation, set the \$MARATHON_APP_ID env var."
 else


### PR DESCRIPTION
The usual dance:
* install jq
* grab public IP out of ECS metadata
* Use the ECS metadata env var as a signal that the server config should be built