### PR TITLE
Switch to `sbtWrapper`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,24 @@
-@Library('socrata-pipeline-library@5.0.0') _
+@Library('socrata-pipeline-library@7.0.0') _
 
 commonPipeline(
   defaultBuildWorker: 'build-worker-pg13',
   jobName: 'query-coordinator',
   language: 'scala',
-  languageVersion: '2.12',
+  languageOptions: [
+      crossCompile: true,
+  ],
   numberOfBuildsToKeep: 50,
   projects: [
     [
       name: 'query-coordinator',
       type: 'service',
       deploymentEcosystem: 'marathon-mesos',
+      compiled: true,
+      paths: [
+        dockerBuildContext: 'query-coordinator/docker'
+      ]
     ]
   ],
   projectWorkingDirectory: 'query-coordinator',
   teamsChannelWebhookId: 'WORKFLOW_IQ',
-  scalaSrcJar: 'query-coordinator/target/query-coordinator-assembly.jar',
-  scalaSubprojectName: 'queryCoordinator',
 )

--- a/build.sbt
+++ b/build.sbt
@@ -16,3 +16,5 @@ val queryCoordinator = (project in file("query-coordinator")).
 disablePlugins(AssemblyPlugin)
 
 releaseProcess -= ReleaseTransformations.publishArtifacts
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"


### PR DESCRIPTION
This commit transitions this repository's Jenkins job to use sbtWrapper, a replacement for the legacy sbtWrapper. sbtWrapper induces backwards incompatible changes in the common pipeline, and the major version of pipelines is accordingly bumped.