### PR TITLE
EN-76223: publish to latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,18 @@
-@Library('socrata-pipeline-library@0.2.0') _
+@Library('socrata-pipeline-library@5.0.0') _
 
-commonServicePipeline(
+commonPipeline(
   defaultBuildWorker: 'build-worker-pg13',
-  deploymentEcosystem: 'marathon-mesos',
+  jobName: 'query-coordinator',
   language: 'scala',
   languageVersion: '2.12',
   numberOfBuildsToKeep: 50,
-  projectName: 'query-coordinator',
+  projects: [
+    [
+      name: 'query-coordinator',
+      type: 'service',
+      deploymentEcosystem: 'marathon-mesos',
+    ]
+  ],
   projectWorkingDirectory: 'query-coordinator',
   teamsChannelWebhookId: 'WORKFLOW_IQ',
   scalaSrcJar: 'query-coordinator/target/query-coordinator-assembly.jar',


### PR DESCRIPTION
This commit updates the Jenkinsfile to use the latest verison of the pipeline library, which will have the effect of publishing the image to the latest tag for each deployment to staging, which is important for our ECS migration.