### PR TITLE
EN-81051: Add some retry logic to the soda3 path

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/ExistenceChecker.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/ExistenceChecker.scala
@@ -59,9 +59,11 @@ object ExistenceChecker {
 
   case object No extends Result
 
-  case object BadResponseFromSecondary extends Result
+  sealed abstract class Error extends Result
 
-  case object TimeoutFromSecondary extends Result
+  case object BadResponseFromSecondary extends Error
 
-  case object SecondaryConnectFailed extends Result
+  case object TimeoutFromSecondary extends Error
+
+  case object SecondaryConnectFailed extends Error
 }


### PR DESCRIPTION
This makes retries happen on both the existence check and the actual query issuance in order to handle connection errors