### PR TITLE
EN-81051: when retrying a query, allow other secondary

### DIFF
--- a/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/NewQueryResource.scala
+++ b/query-coordinator/src/main/scala/com/socrata/querycoordinator/resources/NewQueryResource.scala
@@ -1,6 +1,7 @@
 package com.socrata.querycoordinator.resources
 
 import scala.annotation.tailrec
+import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -307,32 +308,38 @@ class NewQueryResource(
         }
 
         @tailrec
-        def loop(retries: Int): (String, Response) = {
-          val (chosenSecondary, instance) = chosenSecondaries.toStream.flatMap { name =>
-            secondary.unassociatedServiceInstance(name).map((name, _))
-          }.headOption.getOrElse {
+        def loop(retries: Int, secondaries: Queue[String]): (String, Response) = {
+          val (chosenSecondary, remainingSecondaries) = secondaries.dequeueOption.getOrElse {
             throw new Exception(s"None of ${chosenSecondaries} seems to be available?") // this genuinely is an internal error
           }
-          val req = secondary.reqBuilder(instance)
-            .p("new-query")
-            .addHeaders(additionalHeaders)
-            .addHeader(ReqIdHeader, reqId.toString)
-            .blob(new ByteArrayInputStream(serialized))
+          secondary.unassociatedServiceInstance(chosenSecondary) match {
+            case None =>
+              // there were no instances for the chosen secondary,
+              // don't count this as a "retry", but also don't
+              // re-enqueue the chosen secondary.
+              loop(retries, secondaries)
+            case Some(instance) =>
+              val req = secondary.reqBuilder(instance)
+                .p("new-query")
+                .addHeaders(additionalHeaders)
+                .addHeader(ReqIdHeader, reqId.toString)
+                .blob(new ByteArrayInputStream(serialized))
 
-          val respOrRetriableError = try {
-            Right((chosenSecondary, httpClient.execute(req, rs)))
-          } catch {
-            case e: ConnectTimeout => Left(e)
-            case e: ConnectFailed => Left(e)
-          }
+              val respOrRetriableError = try {
+                Right((chosenSecondary, httpClient.execute(req, rs)))
+              } catch {
+                case e: ConnectTimeout => Left(e)
+                case e: ConnectFailed => Left(e)
+              }
 
-          respOrRetriableError match {
-            case Right(result) => result
-            case Left(_) if retries < 3 => loop(retries + 1)
-            case Left(e) => throw e
+              respOrRetriableError match {
+                case Right(result) => result
+                case Left(_) if retries < 3 => loop(retries + 1, remainingSecondaries.enqueue(chosenSecondary))
+                case Left(e) => throw e
+              }
           }
         }
-        val (chosenSecondary, resp) = loop(0)
+        val (chosenSecondary, resp) = loop(0, Queue(chosenSecondaries : _*))
 
         val base = Status(resp.resultCode) ~> Header("x-soda2-secondary", chosenSecondary)
 


### PR DESCRIPTION
When we're issuing a query on the new-analyzer path, if we get a connection-time error or if there are no available instances for the chosen secondary registered in the broker, then try a different secondary in addition to re-fetching a new service instance.